### PR TITLE
feat: /create 입력 플로우 UX 보강

### DIFF
--- a/src/features/meet-create/lib/hostNameStorage.ts
+++ b/src/features/meet-create/lib/hostNameStorage.ts
@@ -1,0 +1,45 @@
+/**
+ * 모임장 이름 영구 저장소 (localStorage)
+ *
+ * - 저장 시점: "날짜 선택하기" CTA 성공 시점에만 (FR-005)
+ * - 수명: 만료 없이 영구 (FR-012)
+ * - 실패 시: 조용히 무시하여 사용자 플로우 유지 (FR-011)
+ */
+
+export const LAST_HOST_NAME_KEY = 'last_host_name';
+
+const HOST_NAME_REGEX = /^[ㄱ-힣a-zA-Z]+$/;
+const MAX_HOST_NAME_LENGTH = 10;
+
+export function readLastHostName(): string {
+  if (typeof window === 'undefined') return '';
+
+  try {
+    const raw = window.localStorage.getItem(LAST_HOST_NAME_KEY);
+    if (!raw) return '';
+
+    const trimmed = raw.trim();
+    if (!trimmed) return '';
+
+    const sliced =
+      trimmed.length > MAX_HOST_NAME_LENGTH
+        ? trimmed.slice(0, MAX_HOST_NAME_LENGTH)
+        : trimmed;
+
+    if (!HOST_NAME_REGEX.test(sliced)) return '';
+
+    return sliced;
+  } catch {
+    return '';
+  }
+}
+
+export function writeLastHostName(value: string): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(LAST_HOST_NAME_KEY, value.trim());
+  } catch (error) {
+    console.warn('[hostNameStorage] Failed to persist last host name', error);
+  }
+}

--- a/src/features/meet-create/model/useMeetCreateForm.ts
+++ b/src/features/meet-create/model/useMeetCreateForm.ts
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 
+import { readLastHostName } from '@/features/meet-create/lib/hostNameStorage';
+
 // 랜덤 모임명 플레이스홀더 목록
 const MEETING_NAME_PLACEHOLDERS = [
   '멋쟁이들 모임',
@@ -18,13 +20,21 @@ const getRandomPlaceholder = () => {
   return MEETING_NAME_PLACEHOLDERS[randomIndex];
 };
 
+// 모임명 허용 문자: 한글, 영문(대소문자), 숫자
+const MEETING_NAME_REGEX = /^[ㄱ-힣a-zA-Z0-9]*$/;
+
 export function useMeetCreateForm(
   initialHostName = '',
   initialMeetingName = '',
 ) {
-  const [hostName, setHostName] = useState(initialHostName);
+  // 초기값 우선순위: URL searchParams > localStorage > '' (AD-6)
+  // SSR에서는 readLastHostName이 항상 '' 반환 → hydration mismatch 없음
+  const [hostName, setHostName] = useState(
+    () => initialHostName || readLastHostName(),
+  );
   const [meetingName, setMeetingName] = useState(initialMeetingName);
   const [hostNameError, setHostNameError] = useState('');
+  const [meetingNameError, setMeetingNameError] = useState('');
 
   // useState의 lazy initializer로 마운트 시 한 번만 랜덤값 생성
   // SSR/CSR 불일치는 Input의 suppressHydrationWarning으로 처리
@@ -48,25 +58,35 @@ export function useMeetCreateForm(
   };
 
   const handleHostNameClear = () => {
+    // Clear는 로컬 저장값을 변경하지 않는다 — 저장은 CTA 성공 시에만 (FR-006, FR-008)
     setHostName('');
     setHostNameError('');
   };
 
   const handleMeetingNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setMeetingName(e.target.value);
+    const newValue = e.target.value;
+    setMeetingName(newValue);
+
+    if (newValue && !MEETING_NAME_REGEX.test(newValue)) {
+      setMeetingNameError('한글, 영문, 숫자만 입력 가능해요');
+    } else {
+      setMeetingNameError('');
+    }
   };
 
   const handleMeetingNameClear = () => {
     setMeetingName('');
+    setMeetingNameError('');
   };
 
-  const isValid = hostName.trim() !== '' && !hostNameError;
+  const isValid = hostName.trim() !== '' && !hostNameError && !meetingNameError;
 
   return {
     hostName,
     meetingName,
     meetingNamePlaceholder,
     hostNameError,
+    meetingNameError,
     isValid,
     handleHostNameChange,
     handleHostNameClear,

--- a/src/features/meet-create/ui/MeetCreatePage.tsx
+++ b/src/features/meet-create/ui/MeetCreatePage.tsx
@@ -7,6 +7,7 @@ import Button from '@/shared/ui/button/Button';
 import Input from '@/shared/ui/input/Input';
 import TopBar from '@/shared/ui/top-bar/TopBar';
 
+import { writeLastHostName } from '../lib/hostNameStorage';
 import { useMeetCreateForm } from '../model/useMeetCreateForm';
 
 interface MeetCreatePageProps {
@@ -24,6 +25,7 @@ export default function MeetCreatePage({
     meetingName,
     meetingNamePlaceholder,
     hostNameError,
+    meetingNameError,
     isValid,
     handleHostNameChange,
     handleHostNameClear,
@@ -63,8 +65,12 @@ export default function MeetCreatePage({
       });
     }
 
+    // 자동 채움용 영구 저장 — CTA 성공 시점에만 (FR-005, FR-006)
+    const trimmedHostName = hostName.trim();
+    writeLastHostName(trimmedHostName);
+
     const params = new URLSearchParams({
-      hostName: hostName.trim(),
+      hostName: trimmedHostName,
       meetingName: finalMeetingName,
     });
     router.replace(`/date?${params.toString()}`);
@@ -96,6 +102,7 @@ export default function MeetCreatePage({
             maxLength={10}
             fullWidth
             required
+            autoFocus
             errorMessage={hostNameError}
           />
 
@@ -108,6 +115,7 @@ export default function MeetCreatePage({
             placeholder={meetingNamePlaceholder}
             maxLength={10}
             fullWidth
+            errorMessage={meetingNameError}
             suppressHydrationWarning
           />
         </div>

--- a/src/shared/ui/input/Input.tsx
+++ b/src/shared/ui/input/Input.tsx
@@ -1,4 +1,10 @@
-import { ComponentProps, KeyboardEvent, useId, useState } from 'react';
+import {
+  ComponentProps,
+  FocusEvent,
+  KeyboardEvent,
+  useId,
+  useState,
+} from 'react';
 
 import Icon from '@/shared/ui/icon/Icon';
 
@@ -51,6 +57,8 @@ export default function Input({
   onClear,
   onChange,
   onKeyDown,
+  onFocus,
+  onBlur,
   suppressHydrationWarning,
   ...props
 }: InputProps) {
@@ -65,6 +73,11 @@ export default function Input({
     if (defaultValue !== undefined) return String(defaultValue).length;
     return 0;
   });
+
+  // 포커스 상태 (X 버튼 노출 조건에 사용 — "편집 중일 때만 지우개 노출")
+  // autoFocus 가 마운트 시 native focus 만 트리거하고 React synthetic onFocus 가 누락되는
+  // 케이스(React 19 + 일부 환경)를 보완하기 위해, autoFocus prop 으로 초기값을 설정한다.
+  const [isFocused, setIsFocused] = useState(!!props.autoFocus);
 
   // 입력 변경 핸들러
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -87,6 +100,16 @@ export default function Input({
       handleClear();
     }
     onKeyDown?.(e);
+  };
+
+  const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
+    setIsFocused(true);
+    onFocus?.(e);
+  };
+
+  const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
+    setIsFocused(false);
+    onBlur?.(e);
   };
 
   // value가 controlled로 넘어오면 해당 길이 사용, 아니면 내부 상태 사용
@@ -114,10 +137,13 @@ export default function Input({
     .filter(Boolean)
     .join(' ');
 
+  // X 버튼은 "포커스 + 값 있음" 일 때만 노출 (편집 문맥에서만 지우개 노출)
+  const showClearButton =
+    isFocused && hasValue && !props.disabled && !props.readOnly;
+
   // 우측 아이콘 공간 확보 (padding-right)
   // X버튼만 내부에 존재 (약 40px)
-  const rightPadding =
-    hasValue && !props.disabled && !props.readOnly ? '40px' : '16px';
+  const rightPadding = showClearButton ? '40px' : '16px';
 
   return (
     <div className={containerClasses}>
@@ -147,16 +173,19 @@ export default function Input({
           maxLength={maxLength}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           style={{ paddingRight: rightPadding }}
           suppressHydrationWarning={suppressHydrationWarning}
           {...props}
         />
 
-        {/* X Button (Only inside input) */}
-        {hasValue && !props.disabled && !props.readOnly && (
+        {/* X Button (Only inside input) - 포커스 + 값이 있을 때만 노출 */}
+        {showClearButton && (
           <div className='input-right-element'>
             <div
               className='input-clear-button'
+              onMouseDown={(e) => e.preventDefault()}
               onClick={handleClear}
               role='button'
               tabIndex={-1}


### PR DESCRIPTION
## Summary

기획 명세 대비 누락됐던 4가지 UX 항목을 `/create` 모임 정보 입력 화면에 보강합니다.

- **모임장 이름 자동 포커스**: `<Input autoFocus />` + Input 내부 `isFocused` 초기값을 autoFocus prop 으로 보강하여 React 19 환경에서 native focus → synthetic onFocus 가 누락되는 케이스도 안전하게 커버
- **포커스 기반 X 버튼**: `isFocused && hasValue` 조건으로 변경. `onMouseDown preventDefault` 로 X 클릭 시 input 이 먼저 blur 되는 경쟁 조건 방지
- **모임장 이름 자동 채움**: `localStorage.last_host_name` 영구 보관, "날짜 선택하기" CTA 성공 시점에만 저장. X 로 비우고 이탈해도 저장값 보존(다른 이름으로 CTA 통과해야만 갱신)
- **모임명 허용 문자 제한**: 한/영/숫자 정규식 화이트리스트, 위반 시 "한글, 영문, 숫자만 입력 가능해요" 에러 + CTA 비활성

초기값 우선순위: URL searchParams > localStorage > ''.
저장소 접근 실패(프라이빗 모드 등)는 silent 처리하여 사용자 플로우 유지.
develop 의 `min-h-screen-safe` 일괄 변경(#125)과 충돌 없이 머지.

closes #69

## Changes

- `src/features/meet-create/lib/hostNameStorage.ts` (신규) — SSR 가드 + try/catch + 길이/정규식 방어 필터를 포함한 read/write 유틸
- `src/features/meet-create/model/useMeetCreateForm.ts` — 초기값 병합, `meetingNameError` state, 정규식 검증, `isValid` 확장
- `src/features/meet-create/ui/MeetCreatePage.tsx` — `autoFocus` prop, `meetingNameError` 전달, `handleSubmit` 성공 시 `writeLastHostName` 호출
- `src/shared/ui/input/Input.tsx` — 내부 `isFocused` 상태, X 버튼 노출 조건 변경, focus 보존 mouseDown preventDefault. **공용 컴포넌트라 다른 화면(participant-* 등)에도 동일 규칙 파급됨**

## Test plan

- [ ] `/` 시작하기 → `/create` 진입 즉시 모임장 이름에 포커스 (탭 없이 키보드 입력 → 필드에 반영)
- [ ] 모임장 이름에 값 입력 후 다른 영역 탭 → X 버튼 사라짐, 다시 포커스 → 다시 노출
- [ ] X 버튼 클릭 → 값 비워지고 포커스 유지 (이어서 타이핑 가능)
- [ ] 모임장 이름 입력 + CTA 성공 → DevTools Application 탭에서 `localStorage.last_host_name` = 입력값 확인
- [ ] 위 상태에서 `/` 다시 갔다가 `/create` 재진입 → 자동 채움 확인
- [ ] 자동 채움된 값을 X 로 비우고 뒤로가기 → 재진입 시 여전히 자동 채움 (저장값 보존)
- [ ] `/create?hostName=김영희` 직접 진입 → URL 우선, localStorage 값은 그대로 유지
- [ ] 모임명에 이모지/특수문자 입력 → "한글, 영문, 숫자만 입력 가능해요" + CTA 비활성, 비우면 다시 활성
- [ ] 회귀: 모임장 이름에 숫자 입력 시 기존 "한글, 영문만 입력 가능해요" 유지
- [ ] 회귀: `participant-register-name`, `participant-edit-name` 등 다른 Input 사용처에서 X 버튼 노출이 자연스러운지 확인 (값 + 포커스 시에만)
- [ ] Private/Incognito 모드 진입 시 자동 채움 미발생 + CTA 제출 정상 (silent 폴백)

🤖 Generated with [Claude Code](https://claude.com/claude-code)