### PR TITLE
feat/#73-vote-rank-cards-api vote-rank-cards-api

### DIFF
--- a/specs/feat/073-vote-rank-cards-api/checklists/requirements.md
+++ b/specs/feat/073-vote-rank-cards-api/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: vote-rank-cards API 연동 및 잔여작업 통합
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — _Note: 백엔드 엔드포인트 경로(`GET /api/v1/meeting`)는 외부 시스템 계약 사실로 인용. 클라 구현은 미명시._
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details) — _SC-002 LCP 표현은 사용자 체감 측정 가능 지표._
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows (P1: 실 데이터 카드 / P2: 표·카드 토글 / P2: PR #72 follow-up)
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- 4개 Clarifications 모두 해소 (API 형태 / 푸터 CTA / badgeGroup 운명 / 기본 뷰)
+- timeRange 유무에 따라 결과 페이지 분기 로직이 추가됨 — `/speckits/plan` 단계에서 폴백 캘린더 뷰의 재사용 가능 여부 확인 필요
+- 의존: PR #71 머지 + PR #72 머지 (현재 PR #72 코드리뷰 완료 단계)
+- 백엔드 응답 스키마는 sandbox swagger 기준 — 운영 환경에서 동일한지 별도 확인 필요

--- a/specs/feat/073-vote-rank-cards-api/contracts/README.md
+++ b/specs/feat/073-vote-rank-cards-api/contracts/README.md
@@ -1,0 +1,109 @@
+# API Contracts: vote-rank-cards API 연동
+
+**Spec**: [../spec.md](../spec.md)
+**Source of Truth**: sandbox swagger `https://sandbox-api.weddin.kr/swagger-ui/index.html`
+
+---
+
+## C-1. `GET /api/v1/meeting`
+
+### Request
+
+| 항목    | 값                                                              |
+| ------- | --------------------------------------------------------------- |
+| Method  | GET                                                             |
+| Path    | `/api/v1/meeting`                                               |
+| Query   | `meetId` (string, required) — 모임 고유 ID                      |
+| Headers | 표준 (`Accept: application/json`) — 별도 인증 헤더 본 spec 무관 |
+
+### Response (200)
+
+```jsonc
+{
+  "id": "abc123", // string
+  "title": "두쫀쿠 투어", // string
+  "hostName": "김야뿌", // string
+  "dates": ["2026-04-17", "2026-04-18"], // string[] (ISO 'YYYY-MM-DD')
+  "status": "VOTING", // 'VOTING' | 'FINALIZED' | 'CLOSED'
+  "finalizedDate": null, // string | null (status==='FINALIZED'일 때만 채워짐)
+  "maxParticipantCount": 9, // number | null
+  "timeRange": {
+    // object | null | undefined
+    "startTime": "12:00", // 'HH:mm' (30분 단위)
+    "endTime": "14:00",
+    "slotCount": 4,
+  },
+  "participants": [
+    {
+      "id": 1, // number
+      "name": "상민", // string
+      "voteDates": ["2026-04-17"], // string[]
+      "voteTimeSlots": [
+        // boolean[][] (dates.length × slotCount)
+        [true, true, false, false],
+      ],
+      "hasVoted": true, // boolean
+    },
+  ],
+}
+```
+
+### Validation Schema (zod)
+
+→ [data-model.md §1](../data-model.md#1-확장된-meetresponsedto-서버--클라-raw)
+
+### Error Responses
+
+| Status              | 의미             | 클라 동작                                                  |
+| ------------------- | ---------------- | ---------------------------------------------------------- |
+| 400                 | meetId 형식 오류 | 결과 페이지 진입 자체 차단 (라우트 가드) — 본 spec 범위 밖 |
+| 404                 | 모임 없음        | "존재하지 않는 모임" 안내 + 홈 이동 CTA (FR-004)           |
+| 5xx / 네트워크 오류 | 서버/네트워크    | "다시 시도" 가능 안내 (FR-004)                             |
+
+### 호출 패턴 (재사용)
+
+```ts
+// src/entities/meet/api/getMeetingById.ts (변경 없음, DTO 확장만으로 자동 반영)
+const rawResponse = await api
+  .get('v1/meeting', { searchParams: { meetId } })
+  .json<unknown>();
+return validateSchema({
+  dto: rawResponse,
+  schema: meetResponseDto,
+  schemaName: 'v1/meeting',
+});
+```
+
+---
+
+## C-2. (참조용) 본 spec에서 호출하지 않는 엔드포인트
+
+| 엔드포인트                                  | 본 spec과의 관계                                                     |
+| ------------------------------------------- | -------------------------------------------------------------------- |
+| `GET /api/v1/meeting/list`                  | 결과 페이지와 무관                                                   |
+| `POST /api/v1/meeting`                      | 모임 생성 (별도 feature)                                             |
+| `POST /api/v1/meeting/vote`                 | 투표 등록 — 푸터 `투표하기` Link로 라우팅, 본 페이지에서 직접 호출 X |
+| `PUT /api/v1/meeting/vote`                  | 투표 수정 — 동일                                                     |
+| `GET /api/v1/host/meeting/finalize/preview` | 호스트 확정 플로우 (out of scope)                                    |
+| `POST /api/v1/host/meeting/finalize`        | 동일                                                                 |
+
+---
+
+## C-3. (제거 후보) 본 spec 시점에 미구현이었지만 사용 안 할 함수
+
+다음 함수는 swagger에 대응 엔드포인트가 없어 호출되지 않음. **본 spec 작업 중에는 제거하지 않고 deprecation 주석만 추가**(plan.md AD-6).
+
+| 함수                    | 위치                                                     | 사유                                                              |
+| ----------------------- | -------------------------------------------------------- | ----------------------------------------------------------------- |
+| `fetchVoteTimeSlotStat` | `entities/voteTimeSlotStat/api/fetchVoteTimeSlotStat.ts` | 서버 엔드포인트 부재. `buildVoteTimeSlotStat` (클라 집계) 로 대체 |
+| `fetchVoteDateStat`     | `entities/voteDateStat/api/fetchVoteDateStat.ts`         | 서버 엔드포인트 부재. `buildVoteDateStat` (클라 집계) 로 대체     |
+
+---
+
+## C-4. 운영 환경 응답 검증
+
+본 contracts는 **sandbox** swagger 기준. 운영 환경에서도 동일한지 본 작업 통합 단계에서 다음 절차로 확인 (quickstart.md 참조):
+
+1. 운영 모임 1건의 ID로 `GET /api/v1/meeting?meetId=...` 호출
+2. 응답에 `voteTimeSlots`, `timeRange.slotCount`, `status` 모두 존재 확인
+3. zod 검증 통과 확인 (`validateSchema` log 없음)

--- a/specs/feat/073-vote-rank-cards-api/data-model.md
+++ b/specs/feat/073-vote-rank-cards-api/data-model.md
@@ -1,0 +1,304 @@
+# Phase 1 Data Model: vote-rank-cards API 연동
+
+**Date**: 2026-05-07
+**Spec**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+
+---
+
+## 1. 확장된 `meetResponseDto` (서버 → 클라 raw)
+
+> **위치**: `src/entities/meet/dto/meet.dto.ts`
+> **변경 종류**: 기존 zod 스키마에 필드 4개 추가, `participantDto`에 1개 추가.
+
+### Before (현재)
+
+```ts
+export const participantDto = z.object({
+  id: z.number(),
+  name: z.string(),
+  voteDates: z.array(z.string()),
+  hasVoted: z.boolean(),
+});
+
+export const meetResponseDto = z.object({
+  id: z.string(),
+  title: z.string(),
+  dates: z.array(z.string()),
+  maxParticipantCount: z.number().nullable(),
+  participants: z.array(participantDto),
+  hostName: z.string(),
+});
+```
+
+### After (본 작업 적용)
+
+```ts
+// 기존 timeRangeDto 에 slotCount 포함된 변형 신규 정의
+export const timeRangeWithSlotCountDto = z.object({
+  startTime: z.string().regex(TIME_PATTERN),
+  endTime: z.string().regex(TIME_PATTERN),
+  slotCount: z.number().int().min(1),
+});
+
+export const participantDto = z.object({
+  id: z.number(),
+  name: z.string(),
+  voteDates: z.array(z.string()),
+  voteTimeSlots: z.array(z.array(z.boolean())).default([]), // ➕
+  hasVoted: z.boolean(),
+});
+
+export const meetingStatusEnum = z.enum(['VOTING', 'FINALIZED', 'CLOSED']);
+
+export const meetResponseDto = z.object({
+  id: z.string(),
+  title: z.string(),
+  dates: z.array(z.string()),
+  status: meetingStatusEnum, // ➕
+  finalizedDate: z.string().nullable().optional(), // ➕
+  maxParticipantCount: z.number().nullable(),
+  participants: z.array(participantDto),
+  hostName: z.string(),
+  timeRange: timeRangeWithSlotCountDto.nullable().optional(), // ➕
+});
+```
+
+### 영향받는 호출 사이트
+
+| 파일                                          | 영향      | 조치                                                                    |
+| --------------------------------------------- | --------- | ----------------------------------------------------------------------- |
+| `src/entities/meet/api/getMeetingById.ts`     | 자동      | 타입 추론으로 `MeetResponse` 새 필드 자동 노출                          |
+| `src/app/meet/[meetingId]/page.tsx`           | ✏️        | `buildMockSnapshot(meetingData)` → `toMeetingVoteSnapshot(meetingData)` |
+| `src/features/meet-create/...`                | ✅ 없음   | createMeetRequestDto만 사용, response 사용 안 함                        |
+| `src/entities/meet/api/meet.query.example.ts` | 검토 필요 | 응답 모의 데이터가 새 필드 누락 시 추가                                 |
+
+---
+
+## 2. `MeetingVoteSnapshot` (어댑터 출력 = 컴포넌트 입력)
+
+> **위치**: `src/features/vote-rank-cards/lib/types.ts` (기존 위치 유지, TODO-8)
+> **변경 종류**: 변경 없음. 기존 타입 그대로 재사용.
+
+```ts
+// 기존 (PR #72에서 도입, 변경 없음)
+export interface MeetingVoteSnapshot {
+  id: string;
+  title: string;
+  dates: IsoDate[];
+  status: MeetingStatus;
+  finalizedDate?: IsoDate | null;
+  maxParticipantCount: number;
+  participants: ParticipantVote[];
+  hostName: string;
+  timeRange: MeetingTimeRange; // ⚠️ 비-optional. 어댑터에서 timeRange 없는 경우 호출 안 함.
+}
+```
+
+### 어댑터 호출 분기
+
+```tsx
+// app/meet/[meetingId]/page.tsx 패턴
+if (meetingData.timeRange) {
+  const snapshot = toMeetingVoteSnapshot(meetingData); // timeRange 보장됨
+  // ... MeetResultTablePage 렌더
+} else {
+  const dateStats = buildVoteDateStat(meetingData);
+  // ... 캘린더 뷰 렌더
+}
+```
+
+---
+
+## 3. `toMeetingVoteSnapshot` 어댑터 (entities)
+
+> **위치**: `src/entities/meet/lib/toMeetingVoteSnapshot.ts` (➕ 신규)
+> **책임**: `MeetResponse` (timeRange 보장된 분기) → `MeetingVoteSnapshot`
+
+### 시그니처
+
+```ts
+import type { MeetResponse } from '@/entities/meet/dto/meet.dto';
+import type { MeetingVoteSnapshot } from '@/features/vote-rank-cards/lib/types';
+
+export interface ToMeetingVoteSnapshotOptions {
+  /** timeRange가 누락된 경우 throw할지 fallback default를 쓸지 */
+  strict?: boolean; // default true
+}
+
+export function toMeetingVoteSnapshot(
+  meet: MeetResponse,
+  options?: ToMeetingVoteSnapshotOptions,
+): MeetingVoteSnapshot;
+```
+
+### 변환 규칙
+
+| 필드                           | 출처                            | 비고                                                                                          |
+| ------------------------------ | ------------------------------- | --------------------------------------------------------------------------------------------- |
+| `id`                           | `meet.id`                       | 그대로                                                                                        |
+| `title`                        | `meet.title`                    | 그대로                                                                                        |
+| `dates`                        | `[...meet.dates].sort()`        | sort: 날짜 오름차순 보장                                                                      |
+| `status`                       | `meet.status`                   | enum 그대로                                                                                   |
+| `finalizedDate`                | `meet.finalizedDate ?? null`    | undefined → null 정규화                                                                       |
+| `maxParticipantCount`          | `meet.maxParticipantCount ?? 0` | null → 0 fallback                                                                             |
+| `hostName`                     | `meet.hostName`                 | 그대로                                                                                        |
+| `timeRange`                    | `meet.timeRange`                | strict 모드: null/undefined면 throw. fallback 모드: 기본 timeRange 합성 (운영에선 호출 안 됨) |
+| `participants[].id`            | `participant.id`                | number 유지                                                                                   |
+| `participants[].name`          | `participant.name`              | 그대로                                                                                        |
+| `participants[].voteDates`     | `participant.voteDates`         | 그대로                                                                                        |
+| `participants[].voteTimeSlots` | `normalizeVoteTimeSlots(...)`   | R-3 정규화                                                                                    |
+| `participants[].hasVoted`      | `participant.hasVoted`          | 그대로                                                                                        |
+
+### Edge case 처리
+
+- `participants` 비어 있음 → 그대로 빈 배열 (`toRankedSlots` 가 isEmpty 처리).
+- `participants[].voteTimeSlots` 차원 mismatch → `normalizeVoteTimeSlots`로 dates × slotCount 격자에 맞춤 (R-3).
+- `timeRange.slotCount === 0` → 비합리적 데이터, strict 모드 throw.
+
+---
+
+## 4. `buildVoteTimeSlotStat` 어댑터 (entities)
+
+> **위치**: `src/entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat.ts` (➕ 신규)
+> **책임**: `MeetResponse` (timeRange 보장) → `VoteTimeSlotStat` (히트맵 입력)
+
+### 시그니처
+
+```ts
+import type { MeetResponse } from '@/entities/meet/dto/meet.dto';
+import type { VoteTimeSlotStat } from '@/entities/voteTimeSlotStat/dto/voteTimeSlotStat.dto';
+
+export function buildVoteTimeSlotStat(meet: MeetResponse): VoteTimeSlotStat;
+```
+
+### 변환 규칙
+
+```ts
+// 입력 raw에서 cells[] 만들기
+const votedParticipants = meet.participants.filter((p) => p.hasVoted);
+const cells = [];
+for (let d = 0; d < meet.dates.length; d++) {
+  for (let s = 0; s < meet.timeRange.slotCount; s++) {
+    const ablePeople = votedParticipants
+      .filter((p) => p.voteTimeSlots[d]?.[s])
+      .map((p) => ({ id: p.id, name: p.name }));
+    cells.push({
+      date: meet.dates[d],
+      slotIdx: s,
+      count: ablePeople.length,
+      participants: ablePeople,
+    });
+  }
+}
+
+return {
+  meetingId: meet.id,
+  dates: [...meet.dates].sort(),
+  cells,
+  allParticipants: votedParticipants.map((p) => ({ id: p.id, name: p.name })),
+};
+```
+
+### `VoteTimeSlotStat` (기존 dto 변경 없음)
+
+```ts
+// src/entities/voteTimeSlotStat/dto/voteTimeSlotStat.dto.ts (현재 그대로)
+export const voteTimeSlotStatDto = z.object({
+  meetingId: z.string(),
+  dates: z.array(z.string()),
+  cells: z.array(timeSlotCellDto),
+  allParticipants: z.array(z.object({ id: z.number(), name: z.string() })),
+});
+```
+
+---
+
+## 5. `buildVoteDateStat` 어댑터 (entities, timeRange-less 폴백)
+
+> **위치**: `src/entities/voteDateStat/lib/buildVoteDateStat.ts` (➕ 신규)
+> **책임**: `MeetResponse` → `VoteDateStat[]` (날짜 캘린더 뷰 입력)
+
+### 시그니처
+
+```ts
+import type { MeetResponse } from '@/entities/meet/dto/meet.dto';
+import type { VoteDateStat } from '@/entities/voteDateStat/dto/voteDateStat.dto';
+
+export function buildVoteDateStat(meet: MeetResponse): VoteDateStat[];
+```
+
+### 변환 규칙
+
+```ts
+const votedParticipants = meet.participants.filter((p) => p.hasVoted);
+return [...meet.dates].sort().map((date) => {
+  const can = [];
+  const cannot = [];
+  for (const p of votedParticipants) {
+    const person = { id: p.id, name: p.name };
+    if (p.voteDates.includes(date)) can.push(person);
+    else cannot.push(person);
+  }
+  return { date, can, cannot };
+});
+```
+
+### `VoteDateStat` (기존 type 변경 없음)
+
+```ts
+// src/entities/voteDateStat/dto/voteDateStat.dto.ts (현재 그대로)
+export type VoteDateStat = {
+  date: string;
+  can: Person[];
+  cannot: Person[];
+};
+```
+
+---
+
+## 6. 데이터 흐름 다이어그램
+
+```
+GET /api/v1/meeting?meetId=X
+       │
+       ▼
+   ky.get + zod validateSchema
+       │
+       ▼  MeetResponse (확장된 DTO)
+       │
+       ├──── timeRange 있음 ────►  toMeetingVoteSnapshot()  ─►  MeetingVoteSnapshot
+       │                          buildVoteTimeSlotStat()  ─►  VoteTimeSlotStat
+       │                                       │
+       │                                       ▼
+       │                            MeetResultTablePage
+       │                              ├─ useViewMode='table' ─► ResultTableView (Heatmap)
+       │                              └─ useViewMode='cards'  ─► VoteRankCardList
+       │
+       └──── timeRange 없음 ───►  buildVoteDateStat()  ─►  VoteDateStat[]
+                                                │
+                                                ▼
+                                  VoteResultsShell + ReactDatepicker
+```
+
+---
+
+## 7. 단위 테스트 매트릭스
+
+| 어댑터                  | 테스트 케이스 (필수)                                                                                                                                                                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `toMeetingVoteSnapshot` | (a) 정상 변환 9명·4슬롯 (b) participants=[] (c) voteTimeSlots 차원 mismatch fallback (d) timeRange null + strict=true → throw                                                                                                                                                              |
+| `buildVoteTimeSlotStat` | (a) 셀 수 = dates × slotCount (b) hasVoted=false 제외 (c) 모든 셀 0표 (d) timeRange.slotCount=1 단일 셀                                                                                                                                                                                    |
+| `buildVoteDateStat`     | (a) date별 can/cannot 분류 (b) hasVoted=false 제외 (c) dates 정렬 보장 (d) 모든 참여자 voteDates=[]                                                                                                                                                                                        |
+| `rankSlots` (기존)      | ➕ **과거 날짜 보조정렬 1케이스** (FR-011, SC-006). "과거"의 정의: **today 이전** — `compareSlot` 의 `isBefore(aDate, todayDate)` 동작에 따라 today **당일은 future 그룹**. 테스트 케이스는 `TODAY = 'YYYY-MM-DD'` 기준으로 today-1 슬롯을 future 그룹(today+N) 보다 뒤에 정렬되는지 검증. |
+
+---
+
+## 8. 타입 호환성 검증 체크리스트
+
+본 spec 적용 후 다음이 컴파일/런타임 통과해야 함:
+
+- [ ] `toMeetingVoteSnapshot(meet).participants[].voteTimeSlots[d][s]` 가 `boolean` 타입
+- [ ] `MeetResultTablePage` props 시그니처 변경 없음
+- [ ] `MeetingVoteSnapshot.timeRange` 가 비-optional 유지 (어댑터 단계에서 보장)
+- [ ] `meet.query.example.ts` mock 응답이 새 필드 포함하도록 갱신 (단위 테스트 깨지지 않게)

--- a/specs/feat/073-vote-rank-cards-api/plan.md
+++ b/specs/feat/073-vote-rank-cards-api/plan.md
@@ -1,0 +1,423 @@
+# Implementation Plan: vote-rank-cards API 연동 및 잔여작업 통합
+
+**Branch**: `feat/#73-vote-rank-cards-api` | **Date**: 2026-05-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/feat/073-vote-rank-cards-api/spec.md`
+
+## Summary
+
+`vote-rank-cards` 와 `meet-result-table` 컴포넌트는 이미 결합돼 있으나(`MeetResultTablePage`가 토글로 두 뷰를 모두 렌더), 실 페이지 진입점인 `app/meet/[meetingId]/page.tsx`가 **mock 시드 기반 `buildMockSnapshot`/`generateMockVoteTimeSlotStat`** 으로 동작 중이다. 본 작업은 (1) `getMeetingById` 응답 DTO를 sandbox swagger 실 스키마(`participants[].voteTimeSlots`, `timeRange`, `status`, `finalizedDate`) 에 맞춰 확장하고, (2) `MeetResponse → MeetingVoteSnapshot` 어댑터를 entities 계층에 추가하며, (3) `timeRange` 유무에 따라 결과 페이지를 시간대 뷰(현행 토글) 또는 날짜 캘린더 뷰로 분기시키고, (4) PR #72 리뷰의 follow-up 정리를 **삭제 없이 deprecation 주석**으로만 표기한다.
+
+사용자 명시 제약: **미사용 파일·더미 데이터는 본 작업에서 제거하지 않고 deprecation 주석으로 표기만 한다**. 향후 별도 정리 PR에서 실제 삭제.
+
+## Technical Context
+
+| 항목                  | 값                                                                                     |
+| --------------------- | -------------------------------------------------------------------------------------- |
+| **Language/Version**  | TypeScript 5                                                                           |
+| **Framework**         | Next.js 16 (App Router), React 19                                                      |
+| **Styling**           | Tailwind CSS 4 + CVA + clsx + tailwind-merge                                           |
+| **HTTP Client**       | ky (`shared/api/client.ts`)                                                            |
+| **Validation**        | zod (`shared/api/validate.ts`의 `validateSchema`)                                      |
+| **Date**              | date-fns 4.1, `shared/lib/date.ts`의 `parseDate` 헬퍼                                  |
+| **State**             | React local state (server 상태는 server component fetch + Next 캐시)                   |
+| **Testing**           | Vitest (lib 단위 테스트), Playwright (e2e — 본 작업 범위 밖)                           |
+| **Storage**           | N/A — 클라 영속화 없음 (토글 선택 기억 안 함, Clarifications 결정)                     |
+| **Target Platform**   | 모바일 웹 (max-w-screen-sm 컨테이너)                                                   |
+| **Project Type**      | single (단일 Next.js 앱, `src/`)                                                       |
+| **Performance Goals** | 결과 페이지 LCP 95p < 2초 (SC-002)                                                     |
+| **Constraints**       | 백엔드 API 호출 1회(`GET /api/v1/meeting`)로 모든 결과 데이터 확보                     |
+| **Scope**             | 1 신규 페이지 분기 + 1 신규 어댑터 + 1 DTO 확장 + 6개 deprecation 주석 + 1 테스트 추가 |
+
+## Constitution Check
+
+| 게이트                                | 상태              | 비고                                                                                                                                          |
+| ------------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **I. FSD 레이어 의존 방향**           | ⚠️ 기존 위반 발견 | `features/meet-result-table` → `features/vote-rank-cards` import (현재 코드). 본 작업은 위반을 추가하지 않으나 해소도 하지 않음. TODO로 추적. |
+| **II. Single `src/` 구조**            | ✅                | 모든 변경이 `src/` 하위.                                                                                                                      |
+| **III. No barrel exports**            | ✅                | 모든 import는 구체 파일 경로 사용. 본 작업도 동일.                                                                                            |
+| **IV. Unidirectional within feature** | ✅                | `lib → model → ui` 순서 유지.                                                                                                                 |
+| **V. Code style**                     | ✅                | function declaration, camelCase 등 모두 준수.                                                                                                 |
+
+### 위반 정당화
+
+**Violation**: `features/meet-result-table` 가 `features/vote-rank-cards` 를 직접 import.
+
+**Why Needed**: `meet-result-table`의 `MeetResultTablePage`가 토글로 두 뷰(표/카드)를 같은 페이지에 노출. PR #133 단계에서 이 결합이 이미 머지됨.
+
+**Simpler Alternative**: `widgets/vote-result/` 에서 두 feature를 조립하는 게 정석. 본 spec 범위 밖이지만 TODO에 추적.
+
+**TODO 추가 항목**: TODO-7 으로 plan에 등재 (아래 "Open Items" 참조).
+
+## Codebase Exploration Findings
+
+### 이미 구현된 것 (재사용)
+
+- [`src/app/meet/[meetingId]/page.tsx`](../../../src/app/meet/[meetingId]/page.tsx) — `getMeetingById` server fetch, `ParticipantHeader`, `VoteActionButtons` 모두 결선.
+- [`src/app/meet/[meetingId]/VoteActionButtons.tsx`](../../../src/app/meet/[meetingId]/VoteActionButtons.tsx) — `/edit`, `/register` Link + Amplitude 트래킹 완비. **FR-010은 사실상 이미 완료**.
+- [`src/features/meet-result-table/ui/MeetResultTablePage.tsx`](../../../src/features/meet-result-table/ui/MeetResultTablePage.tsx) — 토글(`useViewMode`)로 표·카드 뷰 분기 + `vote-rank-cards` 결합 완료.
+- [`src/features/vote-rank-cards/lib/toRankedSlots.ts`](../../../src/features/vote-rank-cards/lib/toRankedSlots.ts) — `MeetingVoteSnapshot → RankedListResult` 어댑터.
+- [`src/features/vote-results-calendar/ui/VoteResultsShell.tsx`](../../../src/features/vote-results-calendar/ui/VoteResultsShell.tsx) — 날짜 단위 결과 뷰 (timeRange-less 폴백).
+- [`src/shared/api/client.ts`](../../../src/shared/api/client.ts), [`shared/api/validate.ts`](../../../src/shared/api/validate.ts) — ky 클라이언트 + zod 검증 패턴.
+- [`src/shared/lib/date.ts`](../../../src/shared/lib/date.ts) — `parseDate` 헬퍼.
+
+### 채워야 할 격차
+
+1. **`meetResponseDto` 스키마 부족** — `participants[].voteTimeSlots`, `timeRange`, `status`, `finalizedDate` 누락.
+2. **mock 데이터 의존** — `buildMockSnapshot` (해시 기반 가짜 voteTimeSlots), `generateMockVoteTimeSlotStat` (해시 기반 셀 통계).
+3. **timeRange 분기 없음** — 현재 timeRange 유무와 무관하게 `MeetResultTablePage`만 렌더.
+4. **DTO ↔ ViewModel 어댑터** — `MeetResponse → MeetingVoteSnapshot` 변환 함수 부재.
+5. **`VoteTimeSlotStat` 파생** — 서버 집계 엔드포인트 없으므로 클라에서 `participants[].voteTimeSlots` 로부터 셀 단위 집계를 만들어야 함.
+
+### 기존 패턴 참고 (1-2 features)
+
+- **`meet-result-table`**: `lib/`(순수 연산: `slotKey`, `computeHeatmapIntensity`, `timeSlotConstants`) + `model/`(`useViewMode`, `useSelectedCell`) + `ui/`(`MeetResultTablePage` 조립 + UI 컴포넌트).
+- **`vote-rank-cards`**: 동일 패턴.
+- **API 호출 패턴** ([`getMeetingById.ts`](../../../src/entities/meet/api/getMeetingById.ts)):
+  ```ts
+  const rawResponse = await api
+    .get(ENDPOINT, { searchParams: { meetId } })
+    .json<unknown>();
+  return validateSchema({
+    dto: rawResponse,
+    schema: meetResponseDto,
+    schemaName: ENDPOINT,
+  });
+  ```
+
+## Architecture Decisions
+
+### AD-1. `MeetingVoteSnapshot` 타입 위치
+
+- **현행**: `src/features/vote-rank-cards/lib/types.ts`
+- **이슈**: `meet-result-table`이 이를 import → feature → feature 의존 (FSD 위반).
+- **고려한 옵션**:
+  - (a) `entities/meet/dto/meet.dto.ts`로 이전
+  - (b) `shared/types/`로 이전
+  - (c) 본 spec에서는 그대로 두고 TODO만 추적
+- **결정**: **(c) 그대로 두고 TODO 추적**. 이유: 본 spec은 데이터 파이프 연결이 핵심이고, 타입 이전은 기존 import 사이트(메인·테스트·스토리) 6+개 파일을 동시 수정하므로 별도 PR이 안전.
+- **FSD 영향**: 위반 유지 (TODO-8).
+
+### AD-2. `MeetResponse → MeetingVoteSnapshot` 어댑터 위치
+
+- **고려한 옵션**:
+  - (a) `entities/meet/lib/toMeetingVoteSnapshot.ts`
+  - (b) `features/vote-rank-cards/lib/toMeetingVoteSnapshot.ts`
+  - (c) `features/meet-result-table/lib/toMeetingVoteSnapshot.ts`
+- **결정**: **(a) `entities/meet/lib/toMeetingVoteSnapshot.ts`**. 이유: 두 features(`meet-result-table`, `vote-rank-cards`)가 모두 소비. entities 계층에 두면 features 양쪽이 의존해도 단방향 유지. 어댑터는 도메인 변환(서버 raw → 클라 ViewModel)이라 명사적이며 entities에 적합.
+- **FSD 영향**: 합법.
+
+### AD-3. `VoteTimeSlotStat` 파생 어댑터 위치
+
+- **고려한 옵션**:
+  - (a) `entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat.ts` (mock 생성기 옆)
+  - (b) `features/meet-result-table/lib/buildVoteTimeSlotStat.ts`
+- **결정**: **(a)**. 이유: mock 생성기와 동일 산출물 모양을 만드는 함수. entities에 두고 `MeetResponse`를 받아 `VoteTimeSlotStat`을 만들어내는 표준 어댑터로 명세.
+- **FSD 영향**: 합법.
+
+### AD-4. timeRange-less 모임 분기 위치
+
+- **고려한 옵션**:
+  - (a) `app/meet/[meetingId]/page.tsx` 에서 if 분기
+  - (b) `features/meet-result-table` 안에서 자체 분기
+  - (c) 별도 widgets 생성
+- **결정**: **(a) page.tsx 에서 if 분기**. 이유: page는 "라우팅 + 조립" 책임. timeRange 유무는 라우팅·뷰 선택 결정이므로 page가 가장 적절. 두 widget(`MeetResultTablePage`, `VoteResultsShell`) 중 하나를 props로 골라 마운트.
+- **FSD 영향**: 합법.
+
+### AD-5. timeRange-less 모임의 데이터 소스
+
+- **현행**: `fetchVoteDateStat`가 throw 미구현 상태.
+- **고려한 옵션**:
+  - (a) `fetchVoteDateStat` 실제 구현 (별도 엔드포인트 가정)
+  - (b) `MeetResponse.participants[].voteDates` 로부터 클라에서 집계 (서버 raw 사용)
+- **결정**: **(b) 클라 집계**. 이유: Swagger 확인 결과 별도 엔드포인트 없음. timeRange-less 모임도 이미 `getMeetingById`로 받은 raw 데이터에서 충분히 도출 가능. `fetchVoteDateStat`는 deprecation 주석 후 보존.
+- **FSD 영향**: 새 파일 `entities/voteDateStat/lib/buildVoteDateStat.ts` 신설.
+
+### AD-6. Deprecation 정책 (사용자 명시 제약 반영)
+
+- **결정**: 모든 미사용·교체 대상 파일/심볼은 **삭제하지 않고** 다음 형식의 주석을 추가:
+  ```ts
+  /**
+   * @deprecated [#73, 2026-05-07] {짧은 사유}.
+   * Replacement: {대체 경로}
+   * Removal target: 별도 정리 PR (TODO-9 참조).
+   */
+  ```
+- 적용 대상은 Phase 1 산출물(아래) 의 "Deprecation 표시 대상" 표 참조.
+
+### AD-7. page.tsx Server/Client 분리 + 로딩·에러 처리 (Analyze 단계 결정)
+
+- **결정**: `app/meet/[meetingId]/page.tsx` 는 **server component 로 유지**. `getMeetingById` 호출과 `generateMetadata` 가 서버에서 실행돼 SEO/오픈그래프 보존(FR-012, SC-008).
+- **클라이언트 결합부 분리**:
+  - timeRange 있는 모임: 기존 `MeetResultTablePage` (이미 client) 그대로 재사용.
+  - timeRange 없는 모임: 신규 client wrapper `MeetResultCalendarClient.tsx` 를 `app/meet/[meetingId]/` 에 추가. props 는 `dateStats: VoteDateStat[]` 만 받고 내부에서 useState(`selectedDate`)·useRef(`calendarRef`) 로 `VoteResultsShell` + `ReactDatepicker` 조합 관리.
+- **로딩**: `app/meet/[meetingId]/loading.tsx` 신규 추가. TopBar·푸터 자리 차지 + 본문 영역에 스켈레톤 카드 3개.
+- **에러**:
+  - `getMeetingById` 응답 status 404 → `try/catch` 후 `notFound()` 호출 (Next 표준).
+  - 5xx/네트워크 → `try/catch` 없이 throw → `app/meet/[meetingId]/error.tsx` 가 처리. error.tsx 는 client component, `reset()` 함수 호출하는 "다시 시도" 버튼 노출.
+- **wrapper 위치 옵션 검토**:
+  - (a) `app/meet/[meetingId]/MeetResultCalendarClient.tsx` (page 옆)
+  - (b) `features/vote-results-calendar/ui/VoteResultsCalendarPage.tsx`
+- **결정**: **(a)** — 본 wrapper 는 `/meet/[meetingId]` 라우트 전용 결합 책임. features 로 옮기면 재사용 의도가 없음에도 의미를 부풀림. 동일 디렉토리의 기존 `ParticipantHeader.tsx`, `VoteActionButtons.tsx` 와 동일 컨벤션.
+- **FSD 영향**: 합법. app 레이어가 client component 를 같은 폴더에 두는 것은 Next.js 표준 패턴이며 constitution I 의 "app: 라우팅 엔트리만" 원칙의 약한 위반이지만 라우트 전용 결합으로 정당화.
+
+---
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/feat/073-vote-rank-cards-api/
+├── spec.md              # 명세 (작성 완료)
+├── plan.md              # 본 파일
+├── research.md          # Phase 0 산출 (생성 대상)
+├── data-model.md        # Phase 1 산출 (생성 대상)
+├── contracts/           # Phase 1 산출 (생성 대상)
+│   └── README.md
+├── quickstart.md        # Phase 1 산출 (생성 대상)
+├── checklists/
+│   └── requirements.md  # 작성 완료
+└── tasks.md             # /speckits/tasks 단계에서 생성
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── app/
+│   ├── [meetingId]/
+│   │   └── page.tsx                        # ⚠️ stub. TODO-1 참조 (본 작업 변경 없음)
+│   ├── meet/[meetingId]/
+│   │   ├── page.tsx                        # ✏️ server component 유지: API → 어댑터 → snapshot. timeRange 분기. notFound() 처리.
+│   │   ├── loading.tsx                     # ➕ 신규: 인-페이지 스켈레톤
+│   │   ├── error.tsx                       # ➕ 신규: 5xx·네트워크 오류 시 reset CTA
+│   │   ├── MeetResultCalendarClient.tsx    # ➕ 신규 client wrapper: timeRange-less 분기 결합 (AD-7)
+│   │   ├── ParticipantHeader.tsx           # 재사용 (변경 없음)
+│   │   └── VoteActionButtons.tsx           # 재사용 (변경 없음)
+│   └── test/vote-rank-cards/page.tsx       # 💬 deprecation 주석 (보존)
+│
+├── features/
+│   ├── meet-result-table/                  # 재사용 (변경 없음, 내부 구조)
+│   │   ├── ui/MeetResultTablePage.tsx
+│   │   ├── ui/ResultTableView.tsx
+│   │   ├── ui/HeatmapGrid.tsx
+│   │   └── ...
+│   ├── vote-results-calendar/              # 재사용 (timeRange-less 폴백)
+│   │   └── ui/VoteResultsShell.tsx
+│   └── vote-rank-cards/
+│       ├── lib/types.ts                    # 💬 RankedSlot.badgeGroup 필드, RankBadgeGroup 타입에 deprecation 주석
+│       ├── lib/toRankedSlots.ts            # 💬 mapBadgeGroup 함수에 deprecation 주석
+│       ├── lib/toRankedSlots.test.ts       # 변경 없음 (테스트는 보존)
+│       ├── lib/rankSlots.test.ts           # ✏️ 과거 날짜 보조정렬 테스트 1케이스 추가 (FR-011)
+│       ├── lib/mock.ts                     # 💬 deprecation 주석 (test 라우트 전용으로 사용)
+│       ├── model/useVoteRankCardToggle.ts  # 💬 isOpen 콜백에 deprecation 주석
+│       └── ui/VoteRankCardsPage.tsx        # 💬 deprecation 주석 (test 라우트 전용)
+│
+├── entities/
+│   ├── meet/
+│   │   ├── dto/meet.dto.ts                 # ✏️ participantDto에 voteTimeSlots, meetResponseDto에 timeRange/status/finalizedDate 추가
+│   │   ├── api/getMeetingById.ts           # 변경 없음 (스키마만 확장)
+│   │   └── lib/                            # ➕ 신규 디렉토리
+│   │       └── toMeetingVoteSnapshot.ts    # ➕ 신규: MeetResponse → MeetingVoteSnapshot
+│   ├── voteTimeSlotStat/
+│   │   ├── api/fetchVoteTimeSlotStat.ts    # 💬 deprecation 주석 (서버 엔드포인트 부재)
+│   │   ├── dto/voteTimeSlotStat.dto.ts     # 재사용 (변경 없음)
+│   │   └── lib/
+│   │       ├── mock.ts                     # 💬 generateMockVoteTimeSlotStat 에 deprecation 주석
+│   │       └── buildVoteTimeSlotStat.ts    # ➕ 신규: MeetResponse → VoteTimeSlotStat
+│   └── voteDateStat/
+│       ├── api/fetchVoteDateStat.ts        # 💬 deprecation 주석 (서버 엔드포인트 부재)
+│       ├── dto/voteDateStat.dto.ts         # 재사용 (변경 없음)
+│       └── lib/
+│           └── buildVoteDateStat.ts        # ➕ 신규: MeetResponse → VoteDateStat[]
+│
+└── shared/                                 # 변경 없음 (validateSchema, parseDate 등 재사용)
+```
+
+**Structure Decision**: single Next.js app under `src/`, FSD layered. 본 spec은 다음으로 구성:
+
+- 6개 신규 파일: 3개 어댑터(`entities/meet/lib/toMeetingVoteSnapshot.ts`, `entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat.ts`, `entities/voteDateStat/lib/buildVoteDateStat.ts`) + 3개 라우트 보조(`app/meet/[meetingId]/loading.tsx`, `error.tsx`, `MeetResultCalendarClient.tsx`)
+- 1개 DTO 확장 (`entities/meet/dto/meet.dto.ts`)
+- 1개 page.tsx 변경 (server 유지 + 어댑터 결합 + timeRange 분기 + notFound)
+- 9개 deprecation 주석 (Phase 1 산출물 표 참조)
+- 1개 테스트 추가 (`rankSlots.test.ts` 과거 날짜 케이스)
+
+---
+
+## Phase 0 — Outline & Research
+
+산출: [research.md](./research.md) (생성 예정)
+
+### 조사 항목
+
+#### R-1. swagger 응답 스키마 정확 매핑
+
+- **Question**: `GET /api/v1/meeting?meetId=X` 의 정확한 JSON 응답 (특히 `timeRange.slotCount`, `participants[].voteTimeSlots` 의 nullable 여부, `finalizedDate` 포맷).
+- **Approach**: sandbox swagger UI에서 실 응답 샘플 확인 또는 ParticipantResponse·MeetingResponse 스키마 다운로드.
+- **Output**: `research.md §R-1` 에 zod 스키마 후보 + 각 필드 nullable·optional 결정.
+
+#### R-2. timeRange 없는 모임의 응답 형태
+
+- **Question**: 시간 범위를 선택 안 한 모임의 응답에서 `timeRange`가 (a) 필드 자체 누락 / (b) `null` / (c) `undefined` 중 어느 쪽인지.
+- **Approach**: swagger 스키마의 optionality + sandbox 실 호출.
+- **Output**: zod 스키마의 `.optional()` / `.nullable()` 결정. timeRange 분기 조건문 작성 기준.
+
+#### R-3. `voteTimeSlots` 의 차원 보장
+
+- **Question**: timeRange 없는 모임에서도 `participants[].voteTimeSlots` 가 빈 배열로 오는지 / 누락되는지.
+- **Approach**: swagger 스키마 + 실 호출.
+- **Output**: 어댑터에서 빈 배열 fallback 처리 정책.
+
+#### R-4. parseISO vs parseDate 일관성 정책
+
+- **Decision**: PR #72 코드리뷰에서 `parseISO`도 date-fns 4.1에선 로컬 자정으로 동작 확인됨(회귀 없음). 다만 프로젝트 컨벤션상 `parseDate` 일원화 권장.
+- **Output**: 본 spec 신규 파일은 `parseDate` 사용. 기존 `parseISO` 유지 (style nit, 별도 PR로 정리).
+
+#### R-5. 토글 영속화 미사용 결정 재확인
+
+- **Decision**: Clarifications 결정 — `useViewMode('table')` 초기값으로 새로고침 시 표 뷰 복귀. 영속화 코드 추가 안 함.
+
+---
+
+## Phase 1 — Design & Contracts
+
+산출:
+
+- [data-model.md](./data-model.md) — 확장된 `meetResponseDto`, `MeetingVoteSnapshot` 매핑 규칙
+- [contracts/README.md](./contracts/README.md) — `GET /api/v1/meeting` 계약 (sandbox swagger 인용)
+- [quickstart.md](./quickstart.md) — 개발자 검증 시나리오
+
+### 데이터 모델 변경 (요약)
+
+#### `entities/meet/dto/meet.dto.ts`
+
+```ts
+// 신규 timeRangeDto는 이미 존재 → meetResponseDto에 포함
+// 신규 participantDto 확장:
+export const participantDto = z.object({
+  id: z.number(),
+  name: z.string(),
+  voteDates: z.array(z.string()),
+  voteTimeSlots: z.array(z.array(z.boolean())), // ➕ 추가
+  hasVoted: z.boolean(),
+});
+
+// meetResponseDto 확장:
+export const meetResponseDto = z.object({
+  id: z.string(),
+  title: z.string(),
+  dates: z.array(z.string()),
+  status: z.enum(['VOTING', 'FINALIZED', 'CLOSED']), // ➕ 추가
+  finalizedDate: z.string().nullable().optional(), // ➕ 추가
+  maxParticipantCount: z.number().nullable(),
+  participants: z.array(participantDto),
+  hostName: z.string(),
+  timeRange: z
+    .object({
+      // ➕ 추가
+      startTime: z.string().regex(TIME_PATTERN),
+      endTime: z.string().regex(TIME_PATTERN),
+      slotCount: z.number().int().min(1),
+    })
+    .nullable()
+    .optional(),
+});
+```
+
+#### 어댑터 시그니처
+
+```ts
+// entities/meet/lib/toMeetingVoteSnapshot.ts
+export function toMeetingVoteSnapshot(meet: MeetResponse): MeetingVoteSnapshot;
+
+// entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat.ts
+export function buildVoteTimeSlotStat(meet: MeetResponse): VoteTimeSlotStat;
+
+// entities/voteDateStat/lib/buildVoteDateStat.ts
+export function buildVoteDateStat(meet: MeetResponse): VoteDateStat[];
+```
+
+#### page.tsx 분기 의사 코드
+
+```tsx
+const meetingData = await getMeetingById(meetingId);
+const snapshot = toMeetingVoteSnapshot(meetingData);
+
+return (
+  <main>
+    <ParticipantHeader ... />
+    {meetingData.timeRange ? (
+      <MeetResultTablePage
+        slotStat={buildVoteTimeSlotStat(meetingData)}
+        snapshot={snapshot}
+      />
+    ) : (
+      <VoteResultsShell ...>
+        <ReactDatepicker stats={buildVoteDateStat(meetingData)} ... />
+      </VoteResultsShell>
+    )}
+    <VoteActionButtons meetingId={meetingId} />
+  </main>
+);
+```
+
+### Deprecation 표시 대상 (사용자 명시 제약)
+
+| 대상                                    | 위치                                                         | 사유                                                     | Replacement                          |
+| --------------------------------------- | ------------------------------------------------------------ | -------------------------------------------------------- | ------------------------------------ |
+| `RankedSlot.badgeGroup`                 | `features/vote-rank-cards/lib/types.ts:52`                   | UI에서 미소비, slot.rank 숫자로 대체                     | `RankChip`이 `slot.rank`로 직접 매핑 |
+| `RankBadgeGroup` 타입                   | `features/vote-rank-cards/lib/types.ts:35`                   | 위 필드 부속                                             | (제거 예정, TODO-9)                  |
+| `mapBadgeGroup` 함수                    | `features/vote-rank-cards/lib/toRankedSlots.ts:48`           | 위 필드 부속                                             | (제거 예정, TODO-9)                  |
+| `useVoteRankCardToggle.isOpen`          | `features/vote-rank-cards/model/useVoteRankCardToggle.ts:25` | 호출자 0개                                               | `openIds.has(id)` 직접 호출          |
+| `vote-rank-cards/lib/mock.ts` 전부      | 동일 경로                                                    | 운영 라우트 mock 의존성 제거 후 test 라우트 외 사용 없음 | (test 라우트가 사라지면 함께 제거)   |
+| `VoteRankCardsPage`                     | `features/vote-rank-cards/ui/VoteRankCardsPage.tsx`          | 운영은 `MeetResultTablePage` 사용                        | `MeetResultTablePage`                |
+| `app/test/vote-rank-cards/page.tsx`     | 동일 경로                                                    | 운영 라우트 결합 후 시각 검증은 storybook으로 충분       | storybook stories                    |
+| `buildMockSnapshot`                     | `app/meet/[meetingId]/page.tsx:87`                           | API 어댑터로 대체                                        | `toMeetingVoteSnapshot`              |
+| `generateMockVoteTimeSlotStat` 호출처   | `app/meet/[meetingId]/page.tsx:125`                          | API 어댑터로 대체                                        | `buildVoteTimeSlotStat`              |
+| `entities/voteTimeSlotStat/lib/mock.ts` | 동일 경로 (생성기 자체)                                      | 위 호출처 deprecation 후 운영 사용 0                     | (제거 예정, TODO-9)                  |
+| `fetchVoteTimeSlotStat`                 | `entities/voteTimeSlotStat/api/fetchVoteTimeSlotStat.ts`     | 서버 엔드포인트 부재 (Swagger 확인)                      | `buildVoteTimeSlotStat` (클라 집계)  |
+| `fetchVoteDateStat`                     | `entities/voteDateStat/api/fetchVoteDateStat.ts`             | 서버 엔드포인트 부재                                     | `buildVoteDateStat` (클라 집계)      |
+
+---
+
+## Open Items / Carry-over TODOs (spec의 TODO 섹션과 plan-only 추가)
+
+본 plan 단계에서 식별된 이월 항목 (spec.md TODO 섹션과 통합·확장):
+
+### TODO-7. (신규) `meet-result-table` 의 `vote-rank-cards` import — FSD 위반
+
+- **Location**: [`src/features/meet-result-table/ui/MeetResultTablePage.tsx`](../../../src/features/meet-result-table/ui/MeetResultTablePage.tsx) 6-10행.
+- **Action**: 두 feature를 조립하는 widget(`widgets/vote-result/ui/VoteResultDataView.tsx`) 으로 추출하거나 `MeetingVoteSnapshot` 타입을 `entities/meet/dto/`로 이전해 import 방향을 합법화.
+- **Defer reason**: 본 spec은 데이터 파이프 연결 우선. 위반 추가 없음.
+
+### TODO-8. (신규) `MeetingVoteSnapshot` 타입 위치 이전
+
+- **Current**: `features/vote-rank-cards/lib/types.ts`
+- **Target**: `entities/meet/dto/` 또는 `shared/types/`
+- **Defer reason**: 6+ import 사이트 동시 변경 필요. 별도 PR.
+
+### TODO-9. (신규) Deprecation 일괄 정리 PR
+
+- **Scope**: 위 "Deprecation 표시 대상" 12개 + spec.md TODO-6 항목.
+- **Trigger**: 본 spec 머지 후 1~2주 안정화 기간을 거쳐 별도 cleanup PR로 일괄 제거.
+
+---
+
+## Phase 2 (NOT in this command — `/speckits/tasks`로 진행)
+
+본 plan 종료 후 `/speckits/tasks` 가 다음 task 들을 생성하게 될 것:
+
+- T-1: `meetResponseDto` zod 스키마 확장 + 기존 사용처 type 호환성 확인
+- T-2: `entities/meet/lib/toMeetingVoteSnapshot.ts` 신규 + 단위 테스트
+- T-3: `entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat.ts` 신규 + 단위 테스트
+- T-4: `entities/voteDateStat/lib/buildVoteDateStat.ts` 신규 + 단위 테스트
+- T-5: `app/meet/[meetingId]/page.tsx` 어댑터 결합 + timeRange 분기
+- T-6~11: 6개 deprecation 주석 추가
+- T-12: `rankSlots.test.ts` 과거 날짜 보조정렬 테스트 추가
+- T-13: 운영 모임 1건으로 e2e 시각 회귀 (수동) — quickstart.md 시나리오
+
+## Complexity Tracking
+
+| Violation                                                             | Why Needed                                                                                                                          | Simpler Alternative Rejected Because                                                                                                 |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `features/meet-result-table` → `features/vote-rank-cards` import 유지 | PR #133 단계에서 머지된 기존 결합. 본 spec은 데이터 파이프가 핵심이라 결합 구조 재배치 동시 진행 시 변경 면적 ≥ 6 파일로 회귀 위험. | widget 추출/타입 이전을 동시 진행 시 본 spec의 SC-001 (mock→실 데이터 일치) 검증과 무관한 회귀 가능성. TODO-7·8로 별도 PR 진행 약속. |

--- a/specs/feat/073-vote-rank-cards-api/quickstart.md
+++ b/specs/feat/073-vote-rank-cards-api/quickstart.md
@@ -1,0 +1,135 @@
+# Quickstart: vote-rank-cards API 연동 검증
+
+**Date**: 2026-05-07
+**Spec**: [spec.md](./spec.md)
+
+본 문서는 개발자가 본 작업의 결과물을 로컬·QA에서 시각·기능적으로 검증할 수 있는 절차를 담는다.
+
+---
+
+## Prerequisites
+
+- 의존 PR 머지 완료: #71, #72 (또는 본 브랜치에 cherry-pick).
+- `.env.development` 의 `NEXT_PUBLIC_API_BASE_URL` 이 sandbox 또는 운영 환경 가리킴.
+- sandbox 모임 ID 1건 (timeRange 있음 / 없음 각각).
+
+---
+
+## Scenario 1 — timeRange 있는 모임
+
+1. `npm run dev` 후 `http://localhost:3000/meet/{meetingId}` 진입.
+2. **검증 포인트:**
+   - [ ] TopBar 에 `{호스트명}님이 초대한 {모임 제목}` 노출
+   - [ ] 헤더에 `N명이 투표했어요` (N = participants.filter(hasVoted).length)
+   - [ ] 기본 뷰 = 히트맵 표
+   - [ ] 토글 클릭 시 카드 리스트로 전환
+   - [ ] 카드의 `N/M` 수치가 sandbox 응답 데이터와 일치
+   - [ ] 카드 펼침 시 가능/불가 명단의 이름·순서가 응답과 일치
+   - [ ] 푸터 `투표 수정하기` 클릭 → `/meet/{id}/edit` 이동
+   - [ ] 푸터 `투표하기` 클릭 → `/meet/{id}/register` 이동
+
+3. **DevTools Network 탭 확인:**
+   - [ ] `GET /api/v1/meeting?meetId=...` 호출 1회만 발생
+   - [ ] `fetchVoteTimeSlotStat` 호출 0건 (deprecation 적용됨)
+
+---
+
+## Scenario 2 — timeRange 없는 모임
+
+1. timeRange 미선택으로 만든 모임 ID로 `/meet/{meetingId}` 진입.
+2. **검증 포인트:**
+   - [ ] TopBar 동일 노출
+   - [ ] 시간대 토글(표/카드) 미노출
+   - [ ] 기존 vote-results-calendar (날짜 단위) 뷰 노출
+   - [ ] 날짜 클릭 시 해당 날짜의 가능/불가 명단 표시 (기존 동작)
+   - [ ] 푸터 두 버튼 동작 동일
+
+---
+
+## Scenario 3 — 빈 상태 (참여자 0명 / 모두 미투표)
+
+1. 갓 만든 모임 (participants=[] 또는 hasVoted=false 만) ID로 진입.
+2. **검증 포인트:**
+   - [ ] timeRange 있는 모임: 카드 뷰 토글 시 `아직 투표한 사람이 없어요` 빈 상태 표시
+   - [ ] timeRange 없는 모임: 캘린더 뷰의 빈 상태 동작 (기존)
+   - [ ] 푸터 두 버튼 모두 노출 (TODO-2 추적 항목)
+
+---
+
+## Scenario 4 — 오류 처리
+
+1. 존재하지 않는 ID로 `/meet/invalid-id` 진입.
+2. **검증 포인트:**
+   - [ ] 404 응답 시 사용자에게 "존재하지 않는 모임" 안내 노출 (개발자 콘솔의 zod 검증 에러가 그대로 노출되지 않음)
+   - [ ] 네트워크 차단 후 진입 시 "다시 시도" 가능한 안내
+
+---
+
+## Scenario 5 — 개발용 라우트 (보존됨)
+
+1. `/test/vote-rank-cards` 진입.
+2. **검증 포인트:**
+   - [ ] 기존 mock fixture (`mockMeetingVoteSnapshot`) 기반 카드 리스트 노출 (시각 회귀 확인용)
+   - [ ] 운영 라우트와 무관하게 동작 (deprecation 주석은 있지만 동작 보존)
+
+---
+
+## Scenario 6 — 단위 테스트
+
+```bash
+# 본 spec에서 추가/변경된 테스트만 빠르게
+npx vitest run src/entities/meet/lib/toMeetingVoteSnapshot.test.ts \
+              src/entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat.test.ts \
+              src/entities/voteDateStat/lib/buildVoteDateStat.test.ts \
+              src/features/vote-rank-cards/lib/rankSlots.test.ts
+```
+
+**기대 결과**: 모든 테스트 통과. 신규 어댑터 3종은 data-model.md §7 의 매트릭스 충족. `rankSlots.test.ts` 는 과거 날짜 보조정렬 케이스 1개 추가 통과.
+
+---
+
+## Scenario 7 — Storybook 회귀
+
+```bash
+npm run storybook
+```
+
+**기대 결과**: 다음 stories 변경 없이 그대로 렌더:
+
+- `Features/VoteRankCards/RankChip` (5개)
+- `Features/VoteRankCards/VoteRankCard` (9개)
+- `Features/VoteRankCards/VoteRankCardsPage` (4개) — deprecation 주석에도 stories는 유지
+- `Features/MeetResultTable/...` (기존)
+
+---
+
+## Scenario 8 — 운영 환경 첫 호출 검증
+
+배포 후 1회 한정 검증 (Production smoke test):
+
+1. 운영 모임 1건의 결과 페이지 진입.
+2. DevTools Network 탭에서 응답 raw JSON 다운로드.
+3. 다음 항목이 응답에 모두 존재 확인:
+   - `participants[*].voteTimeSlots`
+   - `timeRange.slotCount` (timeRange 있는 모임)
+   - `status`
+4. 클라 console 에 zod validation error 0건.
+
+→ contracts/README.md §C-4 의 "운영 환경 응답 검증" 절차.
+
+---
+
+## Pass/Fail 기준
+
+본 quickstart 의 모든 시나리오가 ✅ 일 때 본 spec의 SC-001 ~ SC-007 충족으로 간주.
+
+| Scenario | 충족 SC                                               |
+| -------- | ----------------------------------------------------- |
+| 1        | SC-001, SC-004, SC-008                                |
+| 2        | SC-001 (date-only mode), SC-008                       |
+| 3        | SC-001, SC-003                                        |
+| 4        | SC-003                                                |
+| 5        | (별도 — deprecation 정책 일관성)                      |
+| 6        | SC-005, SC-006, SC-007 (grep 으로 호출 0개 검증 포함) |
+| 7        | (회귀 보호)                                           |
+| 8        | SC-001 (운영 데이터 일치)                             |

--- a/specs/feat/073-vote-rank-cards-api/research.md
+++ b/specs/feat/073-vote-rank-cards-api/research.md
@@ -1,0 +1,204 @@
+# Phase 0 Research: vote-rank-cards API 연동
+
+**Date**: 2026-05-07
+**Spec**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+
+---
+
+## R-1. `GET /api/v1/meeting?meetId=X` 응답 스키마 정확 매핑
+
+**Decision**: sandbox swagger(`https://sandbox-api.weddin.kr/v3/api-docs`) 기준 다음 스키마로 zod 정의.
+
+```ts
+// 확장될 meetResponseDto (core)
+{
+  id: string,
+  title: string,
+  hostName: string,
+  dates: string[],                              // 'YYYY-MM-DD'
+  status: 'VOTING' | 'FINALIZED' | 'CLOSED',
+  finalizedDate: string | null,                 // null when status !== FINALIZED
+  maxParticipantCount: number | null,
+  timeRange: {                                  // optional/nullable on date-only meetings
+    startTime: string,                          // 'HH:mm', 30min step
+    endTime: string,
+    slotCount: number,                          // ≥ 1
+  } | null,
+  participants: {
+    id: number,
+    name: string,
+    voteDates: string[],                        // 'YYYY-MM-DD'
+    voteTimeSlots: boolean[][],                 // dates.length × timeRange.slotCount
+    hasVoted: boolean,
+  }[],
+}
+```
+
+**Rationale**:
+
+- swagger의 `MeetingResponse` + `ParticipantResponse` 명시적으로 위 필드 모두 포함.
+- `timeRange.slotCount`가 응답에 그대로 옴 → 클라이언트가 슬롯 길이를 별도 계산할 필요 없음.
+- `voteTimeSlots`가 2D boolean이라 PR #72의 `MeetingVoteSnapshot.participants[].voteTimeSlots`와 1:1 매핑.
+
+**Alternatives considered**:
+
+- 별도 `voteTimeSlotStat` 집계 엔드포인트 사용 → swagger에 부재. 폐기.
+- `MeetResponse`에 시간대 집계만 받고 raw vote 필요 시 N+1 호출 → 호출 수 증가, 폐기.
+
+**Open**: 운영 환경 응답이 sandbox와 동일한지는 본 작업 통합 단계에서 실 호출 1회로 확인 필요(quickstart.md).
+
+---
+
+## R-2. `timeRange` 의 optionality
+
+**Decision**: `meetResponseDto.timeRange` 는 zod에서 `.nullable().optional()` 양쪽 허용.
+
+```ts
+timeRange: timeRangeWithSlotCountDto.nullable().optional();
+```
+
+**Rationale**:
+
+- 모임 생성 시 시간 범위 미선택이 가능 (`createMeetRequestDto.timeRange.optional()` 으로 이미 정의됨).
+- 백엔드가 응답에서 (a) 필드 제거 / (b) `null` 반환 둘 중 어느 쪽이든 zod가 받아들이도록 안전 마진.
+- TypeScript 타입은 `MeetingTimeRange | null | undefined` 가 되며, page.tsx 분기 조건은 `if (meetingData.timeRange) { ... }` 한 줄로 둘 다 false-y 처리 가능.
+
+**Alternatives considered**:
+
+- `.nullable()` 만 (필드는 존재, 값만 null) → 실 응답이 필드 제거 형태일 때 zod 검증 실패 위험.
+- `.optional()` 만 (값이 null이면 검증 실패) → 백엔드가 null 반환 시 깨짐.
+
+**Validation step**: 실 응답 1건으로 어느 형태인지 확정 후 더 엄격한 스키마로 좁힐 수 있음 (현재 안전 마진).
+
+---
+
+## R-3. `voteTimeSlots` 차원 보장
+
+**Decision**: 어댑터에서 다음 fallback 정책 적용:
+
+- `voteTimeSlots` 가 `undefined`/`null` → 빈 배열 `[]` 로 정규화.
+- 각 행 길이가 `timeRange.slotCount`와 다르면 어댑터가 잘라내거나 false-패딩.
+- timeRange 가 없는 모임에서는 `voteTimeSlots` 를 무시(어차피 결과 페이지가 캘린더 뷰로 분기).
+
+```ts
+function normalizeVoteTimeSlots(
+  raw: boolean[][] | undefined | null,
+  expectedDates: number,
+  expectedSlots: number,
+): boolean[][] {
+  if (!raw)
+    return Array.from({ length: expectedDates }, () =>
+      Array(expectedSlots).fill(false),
+    );
+  return Array.from({ length: expectedDates }, (_, d) => {
+    const row = raw[d] ?? [];
+    return Array.from({ length: expectedSlots }, (_, s) => Boolean(row[s]));
+  });
+}
+```
+
+**Rationale**: 백엔드가 race condition (모임 시간 범위 변경 + 기존 투표 데이터 mismatch) 으로 차원이 안 맞는 응답을 줄 가능성 방어. PR #72의 `toRankedSlots`가 `Boolean(dateRow?.[slotIndex])` fallback을 이미 가지고 있어 어댑터에서 한 번 더 정규화하면 이중 보호.
+
+**Alternatives considered**:
+
+- zod에서 차원 검증 → `slotCount` 알기 위한 cross-field 검증 복잡도 vs 효용 낮음.
+- 어댑터에서 throw → 사용자에게는 무용한 에러. 폐기.
+
+---
+
+## R-4. `parseISO` vs `parseDate` 일관성
+
+**Decision**: 본 작업 신규 코드(어댑터·page 분기)는 `shared/lib/date.ts` 의 `parseDate` 사용. PR #72 기존 코드의 `parseISO`는 별도 정리 PR 대상으로 유지.
+
+**Rationale**:
+
+- 코드리뷰 검증 결과 date-fns 4.1의 `parseISO('YYYY-MM-DD')`는 로컬 자정 반환으로 `parseDate`와 동등하게 동작 (`format()` 결과 timezone 무관 동일). 회귀 위험 없음.
+- 그러나 프로젝트 컨벤션상 `parseDate`로 일원화돼 있고, 1422f98 커밋에서 `new Date(YYYY-MM-DD)` 의 day-shift를 잡은 직후라 동일 헬퍼 사용이 안전.
+- 일괄 변경 시 import 사이트 5+개 동시 수정. 본 spec 범위 비대화 우려.
+
+**Alternatives considered**:
+
+- 본 작업에서 일괄 교체 → 결합도 큰 변경, 회귀 위험.
+- 그대로 방치 → 일관성 비용 누적.
+
+---
+
+## R-5. 토글 영속화 미사용 결정 재확인
+
+**Decision**: `useViewMode` 의 초기값을 `'table'` 로 두고 새로고침 시 표 뷰로 복귀. localStorage 등 영속화 안 함.
+
+**Rationale**: spec Clarifications 결정. 첫 인상 일관성 > 개인화. 향후 사용자 피드백 누적 시 추가 고려 (TODO-4).
+
+---
+
+## R-6. `meet-result-table` ↔ `vote-rank-cards` 의 결합 회로
+
+**Finding**: `MeetResultTablePage` 가 다음을 직접 import:
+
+- `features/vote-rank-cards/lib/toRankedSlots`
+- `features/vote-rank-cards/lib/types` (`MeetingVoteSnapshot`)
+- `features/vote-rank-cards/model/useVoteRankCardToggle`
+- `features/vote-rank-cards/ui/VoteRankCardEmptyState`
+- `features/vote-rank-cards/ui/VoteRankCardList`
+
+**Decision**: 본 spec에서는 결합 회로를 **그대로 유지**하고 `MeetResultTablePage` 에 데이터 입력만 실 어댑터로 교체. FSD 위반 해소(widget 추출 또는 타입 이전)는 TODO-7·8로 별도 PR.
+
+**Rationale**: 본 spec의 핵심 SC-001(mock→실 데이터 일치) 와 무관한 변경. 동시 진행 시 회귀 면적 비대.
+
+---
+
+## R-7. timeRange-less 모임의 캘린더 뷰 어댑터
+
+**Decision**: 새 함수 `entities/voteDateStat/lib/buildVoteDateStat.ts` 작성.
+
+```ts
+// 입력: MeetResponse (timeRange 없음)
+// 출력: VoteDateStat[] (각 후보 날짜에 can/cannot 사람 명단)
+//
+// 알고리즘:
+// 1. snapshot.participants 중 hasVoted=true 만 사용
+// 2. 각 후보 날짜에 대해, 참여자가 voteDates 에 그 날짜를 포함하면 can[], 아니면 cannot[]
+```
+
+**Rationale**: `VoteResultsShell` + `ReactDatepicker` (vote-results-calendar feature) 가 이미 `VoteDateStat[]` 입력 형태로 확립돼 있음. 신규 어댑터로 raw → 입력 변환만 책임 분리.
+
+**Alternatives considered**:
+
+- 캘린더 뷰도 timeRange 있는 모임처럼 시간대 1개 가상화하여 `MeetResultTablePage` 통합 → UX 불일치 (사용자가 시간 안 정한 모임에서 시간 슬롯 보는 혼란).
+- 백엔드 `fetchVoteDateStat` 구현 → swagger에 엔드포인트 부재.
+
+---
+
+## R-8. Deprecation 주석 형식 표준화
+
+**Decision**: 다음 통일 포맷:
+
+```ts
+/**
+ * @deprecated [#73, 2026-05-07] {짧은 사유}.
+ * Replacement: {새 경로 또는 'N/A'}
+ * Removal target: 별도 정리 PR (specs/feat/073-vote-rank-cards-api/plan.md TODO-9 참조).
+ */
+```
+
+**Rationale**:
+
+- `@deprecated` JSDoc 태그로 IDE에서 strikethrough 자동 표시.
+- 이슈 번호·날짜 명시로 회수 시점 추적 가능.
+- Replacement 명시로 신규 사용자에게 대체 경로 제공.
+
+---
+
+## 결정 요약
+
+| ID  | 결정                                                                   | 영향                 |
+| --- | ---------------------------------------------------------------------- | -------------------- |
+| R-1 | meetResponseDto 확장 (voteTimeSlots, timeRange, status, finalizedDate) | DTO 변경 1건         |
+| R-2 | timeRange 는 `.nullable().optional()`                                  | zod 안전 마진        |
+| R-3 | 어댑터에서 voteTimeSlots 차원 정규화                                   | 방어 코드 1개        |
+| R-4 | 신규 코드만 parseDate, 기존 parseISO 유지                              | style 일관성 PR 별도 |
+| R-5 | 토글 영속화 미사용                                                     | 추가 코드 0          |
+| R-6 | feature ↔ feature import 유지 (FSD 위반 carry-over)                    | TODO-7·8             |
+| R-7 | timeRange-less 폴백 = 캘린더 뷰 + 새 어댑터                            | 신규 파일 1          |
+| R-8 | deprecation 주석 표준 포맷                                             | 6+ 곳 적용           |

--- a/specs/feat/073-vote-rank-cards-api/spec.md
+++ b/specs/feat/073-vote-rank-cards-api/spec.md
@@ -1,0 +1,226 @@
+# Feature Specification: vote-rank-cards API 연동 및 잔여작업 통합
+
+**Feature Branch**: `feat/#73-vote-rank-cards-api`
+**Created**: 2026-05-06
+**Status**: Draft
+**Issue**: [#73](https://github.com/nomoney-w2/moit/issues/73)
+**Input**: User description: "이제 api연동을 해보려고 해. 그리고 잔여작업이 뭐인지도 해야함"
+
+## 배경
+
+PR #72 (closed #68) 에서 `vote-rank-cards` 피처를 시각/순위 산정 로직 단계까지 구현했다. 그러나:
+
+- 실제 라우트(`/meet/[meetingId]`) 의 결과 영역은 mock 시드 기반 `buildMockSnapshot`으로 동작 중이며, 사용자별 시간대 투표 정보(`voteTimeSlots`)는 가짜 난수로 만들어진다.
+- 시간대 집계 API(`fetchVoteTimeSlotStat`)는 throw로 미구현 상태다.
+- 백엔드의 모임 조회 응답(`GET /api/v1/meeting`) 은 이미 `participants[].voteTimeSlots`, `timeRange`, `status`를 포함하지만, 프로젝트의 `meetResponseDto`가 이 필드들을 반영하지 못해 컴포넌트 입력(`MeetingVoteSnapshot`) 으로 가는 길이 끊겨 있다.
+- `vote-rank-cards`의 카드 리스트 컴포넌트는 `/test/vote-rank-cards`에만 연결돼 있고, 실 페이지에는 노출되지 않았다 (`MeetResultTablePage` 만 노출). PR #72의 `ViewToggle` placeholder는 표/카드 뷰 전환을 시사한다.
+- PR #72 리뷰에서 도출된 정리 항목(badgeGroup dead field, isOpen dead callback, 푸터 버튼 onClick 미연결, 과거 날짜 정렬 테스트 갭) 이 미해결이다.
+
+본 명세는 위 격차를 한 번의 작업 단위로 좁힌다.
+
+---
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — 실 데이터로 카드 리스트 보기 (Priority: P1)
+
+참여자/호스트가 모임 결과 페이지를 열면, 실제 백엔드에서 받아온 시간대별 투표 집계가 카드 리스트로 표시된다. mock 난수가 아니라 모임 참여자들이 실제로 찍은 표가 1~5위 순위와 가능/불가 명단으로 정확히 보여야 한다.
+
+**Why this priority**: 본 spec의 핵심 가치. 카드 컴포넌트와 순위 알고리즘은 이미 PR #72에서 검증됐으므로 데이터 파이프만 실제로 흐르면 사용자에게 즉시 가치 전달이 가능하다.
+
+**Independent Test**: 실제 모임 ID로 `/meet/[meetingId]`에 진입했을 때 (1) 모임 제목·호스트명이 노출되고 (2) 카드의 `N명이 가능해요` 수치가 백엔드 집계와 일치하며 (3) 카드를 펼쳤을 때 가능/불가 명단의 이름·순서가 백엔드 응답과 일치하는 것을 단일 시나리오로 검증할 수 있다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 8명이 투표를 마친 모임이 있고 그 중 1번 시간대를 7명이 가능으로 찍었다, **When** 호스트가 결과 페이지를 연다, **Then** 1번 시간대 카드가 1위 뱃지와 함께 `7/8`로 표시되고, 펼치면 가능 7명·불가 1명의 실 이름이 노출된다.
+2. **Given** 아무도 투표하지 않은 모임 링크가 있다, **When** 사용자가 결과 페이지를 연다, **Then** `아직 투표한 사람이 없어요` 빈 상태가 보인다.
+3. **Given** 백엔드 응답이 도착 전이다, **When** 결과 페이지를 연다, **Then** 사용자에게 깨진 화면 대신 명확한 로딩 표시(스켈레톤·진행 표시) 가 보이고, 도착 후 카드로 자연 전환된다.
+4. **Given** 백엔드 응답이 4xx/5xx이거나 네트워크 오류다, **When** 결과 페이지를 연다, **Then** 사용자가 상황을 이해할 수 있는 오류 안내 + 재시도 가능 동작이 제공된다.
+
+---
+
+### User Story 2 — 표·카드뷰 전환 (Priority: P2)
+
+같은 결과 데이터를 히트맵 표(이미 노출 중)와 순위 카드 리스트 두 가지 뷰로 토글할 수 있다.
+
+**Why this priority**: PR #72가 `ViewToggle` placeholder를 둔 이유. 두 뷰는 서로 보완적이며(표=시간대 전체 한눈에 / 카드=상위 후보 깊이), 하나만 노출하면 PR #72의 산출물을 일부 묻게 된다. 그러나 데이터가 흐르고 나서 가능한 후속이라 P2.
+
+**Independent Test**: `/meet/[meetingId]` 진입 후 토글 컨트롤을 클릭하면 같은 데이터가 카드 ↔ 표로 전환되고, 한쪽에서 본 1위 시간대가 다른 쪽에서도 동일하게 1위·최다 표로 강조되는지 동일 케이스로 비교 검증 가능.
+
+**Acceptance Scenarios**:
+
+1. **Given** `timeRange`가 있는 모임이고 결과 페이지에 표 뷰(기본)가 보이는 상태, **When** 사용자가 토글의 카드 아이콘을 누른다, **Then** 같은 데이터가 카드 리스트로 전환되어 1~5위와 그 외가 동일 모임 데이터 기준으로 정렬된다.
+2. **Given** `timeRange`가 없는 모임의 결과 페이지에 진입했다, **When** 페이지가 렌더된다, **Then** 시간대 뷰(표·카드) 토글은 노출되지 않고 기존 날짜 단위 결과 캘린더 뷰가 보인다.
+3. **Given** 토글로 카드 뷰를 선택한 상태, **When** 페이지를 새로 고침한다, **Then** 기본 뷰(표) 로 복귀한다 (별도 영속화 안 함).
+
+---
+
+### User Story 3 — PR #72 follow-up 정리 (Priority: P2)
+
+PR #72 코드 리뷰에서 도출된 정리 항목을 본 작업과 함께 처리한다. 사용자에게 직접 보이는 변화는 적지만, 데드 코드를 제거하고 회귀 테스트 갭을 메워 향후 변경 안전성을 높인다.
+
+**Why this priority**: API 연동과 같은 컴포넌트·어댑터를 만지는 작업이므로 같은 PR로 처리하면 리뷰 문맥이 이어지고 별도 PR의 오버헤드가 절감된다. 단, P1이 막히면 보류 가능하므로 P2.
+
+**Independent Test**: 별도 단위 테스트 추가/제거와 잠재적 동작 변화 없음의 실 사용 검증. 데드 코드 제거가 빌드/테스트 통과로 회귀 부재 확인 가능.
+
+**Acceptance Scenarios**:
+
+1. **Given** `RankedSlot.badgeGroup` 필드와 `mapBadgeGroup` 함수가 어댑터에서 사용된다, **When** 작업이 완료된다, **Then** 두 심볼에 deprecation 주석이 부여되고 운영 렌더 경로(`MeetResultTablePage` 트리)에서 `badgeGroup` / `mapBadgeGroup` 호출이 0회임이 grep 으로 확인된다 (코드 자체는 보존).
+2. **Given** `useVoteRankCardToggle` 훅이 `isOpen`을 반환한다, **When** 작업이 완료된다, **Then** `isOpen` 콜백에 deprecation 주석이 부여되고 호출자가 0개임이 grep 으로 확인된다 (코드 자체는 보존, 실제 제거는 TODO-9).
+3. **Given** 푸터의 `투표 수정하기` / `투표하기` 버튼이 onClick 미연결이다, **When** 작업이 완료된다, **Then** 두 버튼이 결과 페이지의 의도된 동작(예: 투표 수정 라우트 이동, 미투표자에 한해 투표 진입) 으로 연결되거나, 결과 페이지에서 노출하지 않기로 명시 결정한다.
+4. **Given** `rankSlots`의 과거 날짜 보조정렬 분기가 미테스트다, **When** 작업이 완료된다, **Then** 과거 날짜 슬롯이 미래보다 뒤로 밀리는 동작이 단위 테스트로 보장된다.
+
+---
+
+### Edge Cases
+
+- 모임이 종료(`status='CLOSED'` 또는 `finalizedDate` 있음)된 경우, 카드 리스트는 그대로 보이되 푸터의 투표 관련 CTA 동작이 달라질 수 있다.
+- 백엔드 응답에 시간 범위(`timeRange`)가 누락된 모임 — `MeetResponse`에는 현재 timeRange가 없음. 시간대 카드는 시간 범위 없이는 의미가 없으므로 명세 단계에서 의존 결정 필요.
+- 참여자 0명 / 모두 `hasVoted=false` 인 경우 빈 상태로 빠진다 (User Story 1 - Acceptance 2).
+- 슬롯 수가 5장 이하·정확히 5장 동률·5장 초과 동률 — PR #72 알고리즘이 이미 처리 중이지만 실 응답 데이터로도 동일 케이스를 시뮬레이션해 회귀 검증.
+- 사용자가 결과 페이지 진입 직후 다른 참여자가 투표를 추가/수정한 경우 — 새로고침 트리거 또는 명시적 갱신 정책.
+- 동일 이름의 참여자가 둘 이상 있는 경우 카드 펼침의 가능/불가 명단에서 식별 — 백엔드 응답이 `id`로 구분 가능하므로 키는 안전, 라벨만 동명이인 처리 정책 결정.
+
+---
+
+## Clarifications
+
+### Session 2026-05-06
+
+- Q: 시간대별 집계 데이터를 어떤 API 형태로 받을까요? → A: Swagger 확인 결과, **`GET /api/v1/meeting?meetId=X`** 가 이미 `participants[].voteTimeSlots: boolean[][]`, `timeRange (slotCount 포함)`, `status`, `finalizedDate` 를 모두 응답함. 별도 시간대 집계 엔드포인트는 존재하지 않음. **결정: 기존 `getMeetingById`의 응답 DTO를 실 서버 스키마에 맞춰 확장**하고, 시간대 집계는 PR #72의 `toRankedSlots` 클라이언트 어댑터로 수행. 미구현된 `fetchVoteTimeSlotStat`은 본 작업에서 deprecation 주석 처리.
+- Q: 결과 페이지 푸터의 `투표 수정하기 / 투표하기` 버튼은 어떻게 처리할까요? → A: **둘 다 유지하고 onClick 연결.** `투표 수정하기` → `/meet/[meetingId]/edit`, `투표하기` → `/meet/[meetingId]/register`. 사용자 식별과 무관하게 두 진입점을 모두 노출.
+- Q: `RankedSlot.badgeGroup` 필드는 어떻게 할까요? → A: **deprecation 주석으로 보존.** 출처 추적 결과 PR #68 data-model에서 정의되고 tasks T011에서 Badge variant 매핑 helper로 쓰일 예정이었으나, PR #72 구현 단계에서 RankChip 컴포넌트로 분리되며 `slot.rank` 숫자로 직접 분기하도록 우회되어 렌더 경로에서 떨어져 나간 데드 필드. 사용자 명시 제약에 따라 본 작업에서는 deprecation 주석만 추가하고, 실제 제거는 별도 정리 PR(TODO-9)로 이월. 색 매핑은 `RankChip`을 단일 출처로 둔다.
+- Q: 결과 페이지 진입 시 기본 뷰는 무엇으로 할까요? → A: **`timeRange` 유무로 분기.** (1) `timeRange`가 있는 모임 → 히트맵 표가 기본, 토글로 카드뷰 전환 (현재 `MeetResultTablePage` 유지 + `VoteRankCardsPage` 결합). (2) `timeRange`가 없는 모임(생성 시 시간 미선택) → 시간대 슬롯이 없으므로 히트맵·카드 둘 다 의미 없음 → **기존 날짜 단위 달력뷰(투표 결과 캘린더)로 폴백.**
+
+### Session 2026-05-07 (Analyze 단계)
+
+- Q: FR-008/SC-005/SC-007 의 "제거" 표현이 사용자 명시 제약과 충돌. → A: **spec 정정.** "제거된다" → "deprecation 주석 표시 + 운영 호출 0개 검증." 실제 제거는 TODO-9.
+
+### Session 2026-05-07 (Implement 단계 진입 시 reality 측량)
+
+- Q: spec/plan/tasks 작성 동안 사용자가 본 브랜치에서 별도 commits를 진행. T019/T020 (badgeGroup deprecation 주석)이 이미 정반대 방향(badgeGroup을 single source로 통합)으로 처리됐고, T021 (isOpen deprecation 주석)이 이미 완전 제거로 처리됨. 어떻게 정합화? → A: **사용자 작업 우선 채택, spec 재정정.** 두 결정 모두 결과적으로 더 정합적: (a) `mapBadgeGroup → slot.badgeGroup → RankChip` 단일 데이터 흐름 (b) `isOpen` 완전 제거가 deprecation보다 깔끔. FR-008/FR-009/SC-005/SC-007 표현을 reality에 맞게 정정. T019/T020/T021/T028은 완료 마킹. 사용자 명시 제약("지금 지우지 말고 주석처리")은 _남은_ deprecation 대상(`fetchVoteTimeSlotStat`, `fetchVoteDateStat`, `buildMockSnapshot`, mock generators)에만 적용.
+- Q: viewMode 타입이 commit [63f91bc](https://github.com/nomoney-w2/moit/commit/63f91bc)에서 `'calendar' → 'list'` 로 rename됨. spec/plan/tasks의 'cards' 표현은 어떻게? → A: 본 spec 문서에서는 의미 명확성 우선으로 "카드 뷰" 라는 한국어 표현 유지 가능. 코드 식별자는 `'list'` 사용 (구현 시 일관 사용).
+- Q: SC-002 LCP 95p < 2초 검증 방법 모호. → A: **SC-002 삭제.** 성능 측정은 본 spec 외 별도 인프라 이슈로 분리.
+- Q: FR-003/FR-004 로딩·오류 UI 구체. → A: **인-페이지 스켈레톤(`loading.tsx`) + 에러 컴포넌트(`error.tsx`).** 404는 `notFound()`, 5xx는 error.tsx 의 reset CTA.
+- Q: timeRange-less 분기에서 ReactDatepicker 의 useState/useRef 상태 관리 위치. → A: **page.tsx 는 server 유지** + 신규 client wrapper 컴포넌트로 결합 분리. `generateMetadata` 의 SEO 동작 보존.
+- Q: "과거 날짜" 의 경계 정의. → A: today **이전** (today 당일은 future 그룹). data-model.md §7 에 명시.
+- Q: NFR-001 SEO 회귀 검증. → A: T013 에 메타 회귀 검증 sub-item 추가. 신규 SC-008 도 추가.
+
+---
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: 시스템은 결과 페이지 진입 시 모임 ID로 `GET /api/v1/meeting?meetId=X` 한 번을 호출해 모임 메타·참여자 raw 투표(`voteTimeSlots`)·`timeRange`·`status`를 함께 받아야 한다. 별도 집계 엔드포인트 호출은 하지 않는다.
+- **FR-002**: 시스템은 백엔드 응답을 `vote-rank-cards`가 소비하는 `MeetingVoteSnapshot`으로 변환하는 어댑터를 제공해야 한다. 현재 PR #72의 `MeetingVoteSnapshot` 형태가 응답 스키마와 사실상 동일하므로, 어댑터는 zod 검증 + 정렬·정규화만 수행한다.
+- **FR-002a**: 프로젝트의 `meetResponseDto`(zod 스키마) 는 실 서버 응답(`participants[].voteTimeSlots`, `timeRange`, `status`, `finalizedDate?`) 을 모두 반영하도록 확장되어야 한다.
+- **FR-002b**: 본 작업 종료 시점에 운영 코드 경로에서 사용되지 않게 되는 함수(`fetchVoteTimeSlotStat`, `fetchVoteDateStat`, `buildMockSnapshot` 등) 와 그에 종속된 보조 자산(mock 생성기·deprecated 타입 필드 등) 은 **deprecation 주석으로 보관**된다 (사용자 명시 제약). 실제 파일·심볼 제거는 별도 정리 PR(plan.md TODO-9)에서 진행한다.
+- **FR-003**: 응답이 도착하기 전 사용자는 결과 페이지 영역에서 인-페이지 스켈레톤(`app/meet/[meetingId]/loading.tsx`) 을 보아야 하며, 깨진 레이아웃을 보아서는 안 된다. TopBar·푸터는 스켈레톤과 함께 즉시 노출된다.
+- **FR-004**: 응답이 404 인 경우 시스템은 Next.js의 `notFound()` 를 호출해 표준 not-found 페이지를 노출한다. 5xx/네트워크 오류 인 경우 `app/meet/[meetingId]/error.tsx` 의 에러 컴포넌트가 사용자에게 상황 안내와 다시 시도 가능한 동작(reset 함수 호출) 을 제공한다.
+- **FR-005**: 시스템은 결과 페이지에서 모임의 `timeRange` 유무에 따라 다음과 같이 분기해야 한다.
+  - `timeRange`가 있는 모임: 결과 페이지에 두 개의 시간대 결과 뷰(히트맵 표 = 기본 / 순위 카드 리스트) 를 제공하고, 사용자가 토글 컨트롤로 전환할 수 있어야 한다.
+  - `timeRange`가 없는 모임(생성 시 시간 미선택): 시간대 뷰는 노출하지 않고, 기존 날짜 단위 결과 캘린더 뷰로 렌더한다.
+- **FR-006**: `/test/vote-rank-cards` 라우트는 본 작업 완료 후 그대로 유지하되, **운영 라우트** `/meet/[meetingId]`가 단일 진입점이 되어야 한다 (test 라우트는 개발용).
+- **FR-007**: PR #72에서 추가된 mock 시드(`buildMockSnapshot`) 의 사용자 가시 노출은 본 작업 완료 시점에 종료되어야 한다 (실 API로 대체).
+- **FR-008**: 색상 그루핑의 단일 진실 원천은 어댑터의 `mapBadgeGroup`이며, `RankedSlot.badgeGroup` 필드를 통해 UI에 전달된다. `RankChip`은 `badgeGroup` props를 받아 색을 결정한다 (자체 매핑 보유 X). **이미 commit [2edab5e](https://github.com/nomoney-w2/moit/commit/2edab5e)에서 통합 완료** — Analyze 단계의 deprecation 결정은 사용자가 더 정합적인 방향(single source 살리기)으로 처리하여 재정정됨.
+- **FR-009**: `useVoteRankCardToggle.isOpen` 콜백은 호출자가 0개임이 확인되어 본 작업에서 완전 제거된다. **이미 commit [351104d](https://github.com/nomoney-w2/moit/commit/351104d)에서 제거 완료** — Analyze 단계의 deprecation 결정은 사용자가 한 단계 진전시켜(완전 삭제) 재정정됨.
+- **FR-010**: 푸터의 `투표 수정하기` / `투표하기` CTA는 둘 다 노출되며, 각각 `/meet/[meetingId]/edit` / `/meet/[meetingId]/register` 라우트로 이동해야 한다.
+- **FR-011**: `rankSlots`의 과거 날짜 보조정렬 동작은 단위 테스트로 보장되어야 한다 ("과거"의 정의: today 이전 날짜 — today 당일은 future 그룹. data-model.md §7 주석 참조).
+- **FR-012**: `app/meet/[meetingId]/page.tsx` 는 server component 로 유지되어 `generateMetadata` 의 SEO/오픈그래프 동작을 보장한다. 클라이언트 상태가 필요한 결합부(timeRange-less 분기의 캘린더 인터랙션 등) 는 별도 client wrapper 컴포넌트로 분리한다.
+
+### Non-Functional Requirements
+
+- **NFR-001**: 결과 페이지 초기 렌더는 SEO/오픈그래프 메타에 영향을 주지 않아야 한다 (현재 `generateMetadata`는 `getMeetingById` 사용 중).
+- **NFR-002**: API 응답 검증은 zod 스키마로 일관 수행한다 (`shared/api/validate.ts` 패턴).
+- **NFR-003**: 어댑터 변환은 순수 함수로 격리되어 단위 테스트로 검증 가능해야 한다.
+
+### Key Entities
+
+- **Meeting (모임)**: 호스트가 만든 일정 조율 단위. `id, title, dates, hostName, status, timeRange?, maxParticipantCount, participants[]` — 본 spec에서 timeRange의 응답 위치 결정 필요.
+- **TimeSlotCell (시간대 셀)**: 한 (날짜, slotIdx) 조합의 집계. `count, participants[]` (가능자 명단). 백엔드 표현.
+- **RankedSlot (순위 슬롯)**: 카드 1장이 표시하는 단위. `rank, canPeople, cannotPeople, startTime, endTime` 등. PR #72에서 정의 완료, 본 spec에서 재사용.
+- **MeetingVoteSnapshot**: PR #72의 입력 모델. 실 API 도입 시 그대로 유지할지/슬림 ViewModel로 교체할지 본 spec의 결정 사항.
+
+---
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: 결과 페이지에서 보이는 카드의 가능자 수·명단이 백엔드 집계와 100% 일치한다 (동일 데이터 기준 mock과의 차이가 0).
+- **SC-003**: 404 시 표준 not-found 페이지, 5xx/네트워크 오류 시 error.tsx 의 "다시 시도" 가능한 안내 화면이 100% 케이스에서 노출된다 (깨진 빈 레이아웃 노출률 0).
+- **SC-004**: PR #72의 `buildMockSnapshot` 호출이 운영 코드 경로에서 0회가 된다.
+- **SC-005**: 색 매핑이 `mapBadgeGroup` (어댑터) → `slot.badgeGroup` → `RankChip` 단일 데이터 흐름으로 통합되고, `RankChip` 내부에 자체 색 룩업 테이블이 없음이 확인된다 ([2edab5e](https://github.com/nomoney-w2/moit/commit/2edab5e)).
+- **SC-006**: `rankSlots`의 과거 날짜 보조정렬을 검증하는 테스트 케이스가 1개 이상 추가된다 ([300a7e2](https://github.com/nomoney-w2/moit/commit/300a7e2)).
+- **SC-007**: `useVoteRankCardToggle`의 반환 시그니처에 `isOpen`이 더 이상 존재하지 않음이 type system으로 보장된다 ([351104d](https://github.com/nomoney-w2/moit/commit/351104d)).
+- **SC-008**: `app/meet/[meetingId]/page.tsx` 가 server component 로 유지되어 `generateMetadata` 가 정상 동작함이 view-source 로 확인된다 (og:title, og:description 노출).
+
+---
+
+## Assumptions
+
+- 백엔드는 시간대별 집계를 서버에서 미리 계산해 내려주는 `voteTimeSlotStatDto` 형태(또는 동등) 를 제공할 것이다 — 클라가 모든 참여자 raw vote를 받아 집계하지 않는다.
+- `timeRange`(시작·종료 시각, slotCount) 는 모임 메타의 일부로 응답에 포함될 것이다. 현재 `meetResponseDto`에는 누락이라 추가 또는 별도 응답 결합이 필요하다.
+- `MeetResponse.participants[].voteDates`는 날짜 단위만 표현하며, 시간대 단위 가능 여부는 별도 시간대 집계 API를 통해서만 확보 가능하다.
+- PR #71 (관련 의존) 머지 이후 본 작업이 시작된다고 가정한다.
+- 토글의 기본 뷰는 히트맵 표 (Clarifications 결정).
+
+---
+
+## Out of Scope
+
+- 카드 리스트 자체의 정렬 알고리즘 변경 (PR #72에서 확정).
+- 새로운 결과 시각화 추가 (3번째 뷰, 차트 등).
+- 모임 종료/확정(`finalizedDate` 처리) 플로우 — SERVICE_OVERVIEW에 따르면 MVP 범위 외.
+- 위치 선택/투표 마감 등 미래 기능.
+- 실시간 동기화(WebSocket 등) — 새로고침으로만 갱신.
+
+---
+
+## Dependencies
+
+- **PR #71** (의존, 머지 대기): 머지 후 본 작업 시작.
+- **PR #72** (선행 머지 필요): vote-rank-cards 컴포넌트·어댑터의 베이스.
+- **백엔드 API** (`GET /api/v1/meeting?meetId=X`): 응답 스키마는 sandbox swagger 기준 확인 완료. 운영 환경 동일 여부는 별도 확인 필요.
+
+---
+
+## TODO / 추적 포인트 _(본 spec 범위 밖이지만 기억해 둘 것)_
+
+화면 플로우 정리 중 도출된 항목들. 본 작업에서 처리하지 않더라도 이후 작업·리뷰 시 놓치지 않도록 명시한다.
+
+### TODO-1. `/[meetingId]` 루트 라우트가 stub 상태
+
+- **현황**: [src/app/\[meetingId\]/page.tsx](../../../src/app/[meetingId]/page.tsx) 가 "모임 ID: xxx" 텍스트만 출력하는 placeholder.
+- **이슈**: `docs/moit/SERVICE_OVERVIEW.md`는 `/[meetingId]`를 메인 모임 페이지로 명시하지만, 실 코드는 `/meet/[meetingId]`만 사용 중. 라우트 의도와 구현이 어긋남.
+- **결정 보류 사유**: 본 spec은 결과 페이지(`/meet/[meetingId]`) 에 집중하므로 범위 밖.
+- **후속 액션**: 루트 stub을 (a) 제거할지, (b) `/meet/[meetingId]`로 redirect할지, (c) SERVICE_OVERVIEW를 코드에 맞게 갱신할지 별도 이슈로 결정.
+
+### TODO-2. 0표 빈 상태에서 푸터 `투표 수정하기` 버튼 활성도
+
+- **현황**: 결과 페이지가 빈 상태(`아직 투표한 사람이 없어요`) 일 때도 푸터의 `투표 수정하기` / `투표하기` 두 버튼이 모두 노출되도록 결정(Clarifications).
+- **이슈**: 0표 상태에서 `투표 수정하기` 진입 시 `/meet/[id]/edit`의 isExist 체크에서 항상 false로 떨어져 사용자가 막다른 길을 마주할 수 있음.
+- **후속 액션**: 디자인과 함께 (a) 0표 상태에서 `투표 수정하기` dim/disable, (b) 진입 후 친절한 빈 상태 안내, (c) 그대로 두고 isExist false 분기를 명확화 중 결정. 본 spec 구현 후 사용 검증해 결정.
+
+### TODO-3. `?trigger=share` 쿼리 동작 명세
+
+- **현황**: 호스트가 모임 생성 직후 `/meet/{id}?trigger=share`로 진입 ([useDateSelect.ts:90](../../../src/features/meet-create-date/model/useDateSelect.ts#L90)).
+- **이슈**: 본 spec 작업 시 결과 페이지를 재구성하면서 이 쿼리 트리거가 의도대로 동작하는지 회귀 검증 필요. 공유 모달 노출 로직이 vote-rank-cards 결합으로 깨지지 않도록 확인.
+- **후속 액션**: plan 단계에서 결과 페이지 컴포넌트 트리를 잡을 때 `?trigger=share` 처리 위치를 명시.
+
+### TODO-4. 토글 선택 영속화 미지원에 따른 사용자 피드백 모니터링
+
+- **현황**: 새로고침 시 기본 뷰(표) 로 복귀(Clarifications). localStorage 영속화 의도적 비포함.
+- **후속 액션**: 출시 후 "내가 보던 뷰가 안 나온다"는 피드백이 누적되면 localStorage 1줄 추가로 해소 가능. 사전에 메트릭/피드백 채널 통해 모니터링.
+
+### TODO-5. 결과 페이지 데이터 갱신 정책 가시화
+
+- **현황**: 다른 참여자가 투표를 추가/수정해도 자동 갱신 안 됨. 새로고침해야 반영(Out of Scope).
+- **이슈**: 사용자가 "왜 내 친구가 투표했다고 했는데 안 보이지?" 라는 혼동을 가질 수 있음.
+- **후속 액션**: (a) 페이지 진입 시 항상 최신 fetch (현재 `getMeetingById`가 server component에서 호출되므로 새로고침 시 최신), (b) 명시적 "새로고침" 버튼 노출, (c) 스냅샷 시각 표시 중 디자인과 함께 결정. 본 spec은 기본 fetch만 보장.
+
+### TODO-6. `voteTimeSlotStat` 엔티티 폴더 정리
+
+- **현황**: `src/entities/voteTimeSlotStat/` 의 `api/fetchVoteTimeSlotStat.ts`가 throw 미구현 상태이며, Swagger 확인 결과 서버에 해당 엔드포인트가 존재하지 않음.
+- **후속 액션**: 본 spec 구현 단계에서 다음 중 결정: (a) `voteTimeSlotStat` 엔티티 폴더 전체 삭제, (b) `dto`/`lib` (mock 생성기·heatmap intensity) 만 보존하고 `api/`만 제거. `MeetResultTablePage`가 `dto/lib`를 의존하는지 확인 후 처리.

--- a/specs/feat/073-vote-rank-cards-api/tasks.md
+++ b/specs/feat/073-vote-rank-cards-api/tasks.md
@@ -1,0 +1,275 @@
+# Tasks: vote-rank-cards API 연동 및 잔여작업 통합
+
+**Feature Branch**: `feat/#73-vote-rank-cards-api`
+**Spec**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+**Data Model**: [data-model.md](./data-model.md)
+**Contracts**: [contracts/README.md](./contracts/README.md)
+**Quickstart**: [quickstart.md](./quickstart.md)
+
+**User constraint (사용자 명시 제약)**: 미사용하게 될 파일·더미 데이터는 **삭제하지 않고 deprecation 주석만 추가**한다. 실제 삭제는 별도 정리 PR(TODO-9).
+
+---
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 다른 파일·기존 미완 의존 없음, 병렬 실행 가능
+- **[Story]**: US1, US2, US3 — Setup/Foundational/Polish 단계는 라벨 없음
+
+## Path Conventions
+
+Single Next.js app, FSD layered. 모든 경로는 `/Users/yejin/Desktop/moit/` 기준 상대.
+
+```
+src/app/                           # Next.js routing (thin pages)
+src/features/{feature}/{ui|model|lib}/
+src/entities/{entity}/{api|dto|lib}/
+src/shared/{ui|lib|api|...}/
+```
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: 베이스라인 확인. 신규 인프라는 없음 (기존 next/typescript/zod/ky/vitest 환경 그대로 사용).
+
+- [x] T001 현재 브랜치가 `feat/#73-vote-rank-cards-api`인지 확인하고, `npm install` 후 `npx tsc --noEmit` 으로 베이스라인 타입 체크 통과 확인
+- [x] T002 의존 PR(#71, #72)이 본 브랜치 히스토리에 포함됐는지 확인 (`git log --oneline | head -20`)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: 모든 user story가 의존하는 DTO 확장. 이 phase가 끝나야 어댑터·페이지 변경이 type-safe.
+
+**⚠️ CRITICAL**: T003 완료 전에는 어떤 user story task도 시작 불가.
+
+- [x] T003 `src/entities/meet/dto/meet.dto.ts` 에 다음 zod 스키마 확장 (data-model.md §1):
+  - `timeRangeWithSlotCountDto` 신규 추가 (`startTime`, `endTime`, `slotCount`)
+  - `meetingStatusEnum` 신규 추가 (`'VOTING' | 'FINALIZED' | 'CLOSED'`)
+  - `participantDto` 에 `voteTimeSlots: z.array(z.array(z.boolean())).default([])` 추가
+  - `meetResponseDto` 에 `status`, `finalizedDate?: nullable`, `timeRange?: nullable` 추가
+  - 모든 신규 export type 추가 (`MeetingStatus`, `MeetingTimeRangeWithSlotCount` 등)
+- [x] T004 `src/entities/meet/api/meet.query.example.ts` 의 mock 응답이 새 필드 포함하도록 갱신 (없으면 vitest 깨짐 방지)
+- [x] T005 `npx tsc --noEmit` 로 DTO 변경 후 기존 호출 사이트 타입 호환성 확인. 깨지는 곳 있으면 임시 fallback (`?? null`, `?? 0`) 만 적용하고 주석으로 표시
+- [x] T006 [P] `src/shared/lib/date.ts` 의 `parseDate` export 확인 (이미 있음). 신규 어댑터에서 사용 예정이므로 import path 점검만
+
+**Checkpoint**: DTO 확장 완료 → user story 작업 시작 가능
+
+---
+
+## Phase 3: User Story 1 — 실 데이터로 카드/캘린더 보기 (Priority: P1) 🎯 MVP
+
+**Goal**: `/meet/{meetingId}` 페이지가 mock 시드가 아닌 실 API 응답으로 동작. timeRange 유무에 따라 시간대 뷰 또는 날짜 캘린더 뷰로 분기.
+
+**Independent Test**: sandbox 모임 ID로 `/meet/{id}` 진입 → 카드의 가능자 수·명단이 응답 데이터와 100% 일치 + DevTools에서 `GET /api/v1/meeting` 1회만 호출.
+
+### Tests for User Story 1 (data-model.md §7 매트릭스)
+
+- [x] T007 [P] [US1] `src/entities/meet/lib/toMeetingVoteSnapshot.test.ts` 신규 작성: (a) 정상 변환 9명·4슬롯, (b) `participants=[]`, (c) `voteTimeSlots` 차원 mismatch fallback, (d) `timeRange=null + strict=true` → throw
+- [x] T008 [P] [US1] `src/entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat.test.ts` 신규 작성: (a) 셀 수 = `dates × slotCount`, (b) `hasVoted=false` 제외, (c) 모든 셀 0표, (d) `slotCount=1` 단일 셀
+- [x] T009 [P] [US1] `src/entities/voteDateStat/lib/buildVoteDateStat.test.ts` 신규 작성: (a) date별 can/cannot 분류, (b) `hasVoted=false` 제외, (c) dates 정렬 보장, (d) 모든 참여자 `voteDates=[]`
+
+### Implementation for User Story 1
+
+- [x] T010 [P] [US1] `src/entities/meet/lib/toMeetingVoteSnapshot.ts` 신규 구현 (data-model.md §3): `MeetResponse → MeetingVoteSnapshot` 어댑터. 시그니처는 `(meet, options?: { strict?: boolean }) => MeetingVoteSnapshot`. 내부에 `normalizeVoteTimeSlots` 헬퍼 포함 (research.md R-3).
+- [x] T011 [P] [US1] `src/entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat.ts` 신규 구현 (data-model.md §4): `MeetResponse → VoteTimeSlotStat`. `participants[].voteTimeSlots` 로 `cells[]` 합성.
+- [x] T012 [P] [US1] `src/entities/voteDateStat/lib/buildVoteDateStat.ts` 신규 구현 (data-model.md §5): `MeetResponse → VoteDateStat[]`. 날짜별 `voteDates.includes(date)` 분류.
+- [x] T013 [US1] `src/app/meet/[meetingId]/page.tsx` 변경 (T010~T012, T013a 의존). page.tsx는 **server component 유지** (FR-012, SC-008):
+  - `buildMockSnapshot(meetingData)` → `toMeetingVoteSnapshot(meetingData)` 교체
+  - `generateMockVoteTimeSlotStat(meetingId, sortedDates)` → `buildVoteTimeSlotStat(meetingData)` 교체
+  - `meetingData.timeRange ? <MeetResultTablePage .../> : <MeetResultCalendarClient dateStats={buildVoteDateStat(meetingData)} />` 분기 추가
+  - 진입 시 `getMeetingById` 실패 처리: 404 응답을 try/catch 후 `notFound()` 호출. 5xx는 그대로 throw하여 `error.tsx`에 위임 (T015d)
+  - **회귀 검증**: page.tsx가 'use client' 디렉티브 없이 server component로 유지되는지, `generateMetadata` 가 빌드 시 server에서 실행되는지 확인 (NFR-001, SC-008)
+- [x] T013a [US1] `src/app/meet/[meetingId]/MeetResultCalendarClient.tsx` 신규 client wrapper 컴포넌트 생성 (plan.md AD-7). `'use client'` 디렉티브 + props `{ dateStats: VoteDateStat[] }`. 내부에서 `useState(selectedDate)`·`useRef(calendarRef)` 로 `VoteResultsShell` + `ReactDatepicker` 조합. 기존 `VoteResultsShell.stories.tsx`의 표준 결합 패턴을 참고
+- [x] T014 [US1] `src/app/meet/[meetingId]/page.tsx` 의 `buildMockSnapshot` 함수와 `hashSeed`/`mulberry32`/`VISUAL_NAMES`/`VISUAL_POOL_SIZE` 상수에 deprecation 주석 추가 (research.md R-8 표준 포맷). 코드는 보존.
+- [x] T015a [US1] `src/app/meet/[meetingId]/loading.tsx` 신규 추가 (FR-003): TopBar·푸터 자리 차지 + 본문 스켈레톤 카드 3개. server component (Next.js 표준 loading 컨벤션)
+- [x] T015b [US1] `src/app/meet/[meetingId]/error.tsx` 신규 추가 (FR-004): `'use client'` + props `{ error, reset }`. 사용자 친화 안내 + "다시 시도" 버튼이 `reset()` 호출. 5xx·네트워크 오류 처리
+
+**Checkpoint**: User Story 1 완료 시 quickstart.md Scenario 1·2·3·4 통과
+
+---
+
+## Phase 4: User Story 2 — 표·카드 토글 동작 (Priority: P2)
+
+**Goal**: 토글 자체는 PR #133 단계에서 이미 결합됨. 본 phase는 T013의 timeRange 분기와 결합해 (a) timeRange 있는 모임 = 토글 노출 동작, (b) timeRange 없는 모임 = 토글 미노출 동작 검증.
+
+**Independent Test**: timeRange 있는 모임 ID로 진입 → 표 ↔ 카드 토글 클릭 시 같은 데이터 양쪽 일치. timeRange 없는 모임 → 토글 자체 미노출 + 캘린더 뷰만.
+
+- [ ] T016 [US2] quickstart.md Scenario 1 의 토글 동작 manual QA: 표 → 카드 전환 시 같은 모임 데이터 기준으로 1위가 양쪽 동일하게 강조되는지
+- [ ] T017 [US2] quickstart.md Scenario 2 manual QA: timeRange 미선택 모임에서 시간대 토글 자체가 노출되지 않고 캘린더 뷰만 보이는지
+- [ ] T018 [US2] 새로고침 시 기본 뷰(표) 복귀 확인 (Clarifications: localStorage 영속화 안 함)
+
+**Checkpoint**: User Story 1 + 2 모두 동작 = `/meet/{id}` 페이지 운영 사용 가능 상태
+
+---
+
+## Phase 5: User Story 3 — PR #72 follow-up 정리 (Priority: P2)
+
+**Goal**: PR #72 리뷰의 잔여 항목을 코멘트 + 1개 테스트 추가로 완료. 사용자 가시 변화는 없으나 향후 정리 PR을 위한 발판.
+
+**Independent Test**: deprecation 주석 후 `npm run lint && npx tsc --noEmit && npx vitest run` 모두 통과. `rankSlots` 신규 테스트 케이스 통과.
+
+### Deprecation 주석 추가 (전부 [P] — 서로 다른 파일)
+
+- [x] ~~T019 [P] [US3] `src/features/vote-rank-cards/lib/types.ts` 의 `RankBadgeGroup` 타입과 `RankedSlot.badgeGroup` 필드에 deprecation 주석~~ → **취소.** [2edab5e](https://github.com/nomoney-w2/moit/commit/2edab5e)에서 `badgeGroup`을 single source로 통합. deprecation 대신 ALIVE 처리됨. 본 task는 reality에 맞게 무효.
+- [x] ~~T020 [P] [US3] `src/features/vote-rank-cards/lib/toRankedSlots.ts` 의 `mapBadgeGroup` 함수와 그 호출 부분(L133, L168)에 deprecation 주석~~ → **취소.** 위와 같은 이유. `mapBadgeGroup`이 single source로 살아남음.
+- [x] T021 [P] [US3] `src/features/vote-rank-cards/model/useVoteRankCardToggle.ts` 의 `isOpen` 콜백 → **완전 제거 완료** ([351104d](https://github.com/nomoney-w2/moit/commit/351104d)). spec의 deprecation 주석 결정보다 한 단계 진전된 처리.
+- [x] T022 [P] [US3] `src/features/vote-rank-cards/lib/mock.ts` 파일 상단에 deprecation 주석 (test 라우트·storybook 전용). 동작 보존.
+- [x] T023 [P] [US3] `src/features/vote-rank-cards/ui/VoteRankCardsPage.tsx` 파일 상단에 deprecation 주석 (운영은 `MeetResultTablePage` 사용).
+- [x] T024 [P] [US3] `src/app/test/vote-rank-cards/page.tsx` 파일 상단에 deprecation 주석 (개발용 라우트, 시각 회귀는 storybook으로 대체 가능 명시).
+- [x] T025 [P] [US3] `src/entities/voteTimeSlotStat/api/fetchVoteTimeSlotStat.ts` 의 throw 함수에 deprecation 주석 (서버 엔드포인트 부재, `buildVoteTimeSlotStat` 대체).
+- [x] T026 [P] [US3] `src/entities/voteTimeSlotStat/lib/mock.ts` 의 `generateMockVoteTimeSlotStat` 함수에 deprecation 주석 (`buildVoteTimeSlotStat` 대체).
+- [x] T027 [P] [US3] `src/entities/voteDateStat/api/fetchVoteDateStat.ts` 의 throw 함수에 deprecation 주석 (서버 엔드포인트 부재, `buildVoteDateStat` 대체).
+
+### 테스트 갭 메우기 (FR-011, SC-006)
+
+- [x] T028 [US3] `src/features/vote-rank-cards/lib/rankSlots.test.ts` 과거 날짜 보조정렬 테스트 → **완료** ([300a7e2](https://github.com/nomoney-w2/moit/commit/300a7e2)). 케이스 `'동률 그룹 내 과거 날짜는 미래 날짜 뒤로 밀림'` 추가됨.
+
+**Checkpoint**: User Story 3 완료 시 SC-005·SC-006·SC-007 충족
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: 통합 검증, 회귀 보호, 운영 환경 smoke test.
+
+- [x] T029 [P] `npx vitest run src/entities/meet/lib/ src/entities/voteTimeSlotStat/lib/ src/entities/voteDateStat/lib/ src/features/vote-rank-cards/lib/` 로 신규+변경 테스트 일괄 통과 확인 (quickstart.md Scenario 6)
+- [x] T030 [P] `npm run lint` 통과 확인 (deprecation 주석이 ESLint `deprecation/deprecation` 규칙에 걸리는지 점검 — 본 작업 코드에서 호출하지 않으면 OK)
+- [x] T031 [P] `npx tsc --noEmit` 전체 타입 체크 통과
+- [ ] T032 quickstart.md Scenario 1·2·3·4 manual QA (timeRange 있/없 모임 각 1건 + 빈 상태 + 오류 케이스)
+- [ ] T033 [P] quickstart.md Scenario 5: `/test/vote-rank-cards` 진입해 deprecation 주석에도 mock 기반 시각 회귀 정상 확인
+- [ ] T034 [P] quickstart.md Scenario 7: `npm run storybook` → `Features/VoteRankCards/*` 와 `Features/MeetResultTable/*` stories 시각 회귀 0건
+- [ ] T035 (배포 후) quickstart.md Scenario 8: 운영 모임 1건의 결과 페이지 진입해 zod validation error 0건, `voteTimeSlots`/`timeRange.slotCount`/`status` 응답 존재 확인
+- [ ] T036 PR 본문에 본 spec과 plan의 TODO-1~9를 명시적으로 carry-over로 기재 (별도 정리 PR 시 추적 가능하도록)
+
+---
+
+## Dependencies
+
+```
+T001 (Setup)
+   └── T002 (Setup)
+         └── T003 (Foundational: DTO extension) ⚠️ ALL stories block here
+               ├── T004, T005, T006 (Foundational follow-ups)
+               │
+               ├──→ Phase 3 (US1)
+               │      ├── T007 ⫷ T008 ⫷ T009 (tests, parallel)
+               │      ├── T010 ⫷ T011 ⫷ T012 (adapters, parallel)
+               │      ├── T013a (MeetResultCalendarClient wrapper) — depends on T012
+               │      ├── T013 (page.tsx wiring + 분기 + notFound) — depends on T010, T011, T013a
+               │      ├── T014 (deprecation 주석 in page.tsx) — depends on T013
+               │      └── T015a ⫷ T015b (loading.tsx, error.tsx — parallel)
+               │
+               ├──→ Phase 4 (US2) — depends on T013 완료
+               │      ├── T016, T017, T018 (manual QA)
+               │
+               ├──→ Phase 5 (US3) — independent of T013, can run parallel to Phase 3
+               │      ├── T019~T027 (deprecation 주석, all parallel)
+               │      └── T028 (rankSlots test)
+               │
+               └──→ Phase 6 (Polish) — depends on Phase 3·5 완료
+                      ├── T029~T031 (자동화 검증, parallel)
+                      ├── T032 (manual QA)
+                      ├── T033, T034 (storybook/test route 회귀)
+                      ├── T035 (배포 후 smoke test)
+                      └── T036 (PR 본문 TODO carry-over)
+```
+
+### Story 완료 순서 (MVP 배달)
+
+1. **MVP**: Phase 1 → 2 → 3 (US1) → 6 부분 (T029~T032) — 운영 가능 상태
+2. **+US2 검증**: T016~T018 (US1 머지 후 매뉴얼 QA로 즉시 확인)
+3. **+US3 정리**: Phase 5 (US3) 는 US1과 독립적이므로 병렬 PR 또는 같은 PR에 묶을 수 있음
+
+---
+
+## Parallel Execution Examples
+
+### Phase 3 (US1) 의 어댑터 3종 동시 작성
+
+```
+# 다른 파일이고 의존 없음, 동시 작업 가능
+T010 [P] [US1] toMeetingVoteSnapshot.ts
+T011 [P] [US1] buildVoteTimeSlotStat.ts
+T012 [P] [US1] buildVoteDateStat.ts
+```
+
+테스트 3종도 동일하게 병렬:
+
+```
+T007 [P] [US1] toMeetingVoteSnapshot.test.ts
+T008 [P] [US1] buildVoteTimeSlotStat.test.ts
+T009 [P] [US1] buildVoteDateStat.test.ts
+```
+
+### Phase 5 (US3) 의 deprecation 주석 9건 동시 추가
+
+```
+T019~T027 모두 [P] — 서로 다른 파일에 주석만 추가, 의존 없음
+```
+
+### Phase 6 의 자동화 검증 3종 동시 실행
+
+```
+T029 [P] vitest 통과
+T030 [P] lint 통과
+T031 [P] tsc 통과
+```
+
+---
+
+## Implementation Strategy (제안)
+
+### Path A — 단일 PR (권장)
+
+US1 + US3 을 같은 PR로 묶고, US2 는 manual QA로만 검증. 이유: deprecation 주석은 본 작업 컨텍스트에 직접 종속(`buildMockSnapshot` 대체와 같은 시점), 별도 PR 분리 시 리뷰 문맥 손실.
+
+순서:
+
+1. Foundational (T003~T006) → 머지 가능 상태로 만들고 push
+2. US1 어댑터 3종 + 테스트 (T007~T012) — 병렬
+3. US1 page.tsx 결합 (T013~T015)
+4. US3 deprecation 주석 일괄 (T019~T027) + 테스트 추가 (T028)
+5. Polish (T029~T034)
+6. PR 머지 → 배포 → T035 smoke test
+
+### Path B — 분할 PR
+
+PR-A: Foundational + US1 (T003~T015 + T029~T032)
+PR-B: US3 정리 (T019~T028)
+
+장점: PR-A 가 빨리 머지돼 운영 노출. 단점: US3 가 별도 리뷰 문맥에서 진행되어 본 spec 의도(같이 정리) 가 흐려짐.
+
+→ **Path A 권장.** spec scope 결정에서 사용자가 "API 연동 + 잔여작업 통합" 옵션을 선택했으므로.
+
+---
+
+## Validation Checklist (tasks.md 자체 검증)
+
+- [x] 모든 task 가 `- [ ] T### [P?] [Story?] ...` 포맷 준수
+- [x] Setup/Foundational/Polish 단계는 [Story] 라벨 없음
+- [x] User Story phase 의 모든 task 는 [US?] 라벨 보유
+- [x] 각 task 에 명확한 file path 포함
+- [x] [P] 표시는 동일 파일 충돌·미완료 의존 없는 task 에만 부여
+- [x] User Story 1 (P1) 만으로도 독립적으로 MVP 가치 전달 가능 (timeRange 있/없 모임 모두 실 데이터로 결과 페이지 동작)
+- [x] data-model.md §7 의 단위 테스트 매트릭스 모든 케이스가 task 로 매핑됨
+- [x] contracts/README.md 의 `GET /api/v1/meeting` 가 T003 의 DTO 확장으로 매핑됨
+- [x] research.md 의 R-1 ~ R-8 결정이 모두 task 로 반영됨
+
+---
+
+## Summary
+
+| 항목                       | 값                                                                                          |
+| -------------------------- | ------------------------------------------------------------------------------------------- |
+| **Total tasks**            | 38                                                                                          |
+| **Setup**                  | 2 (T001-T002)                                                                               |
+| **Foundational**           | 4 (T003-T006)                                                                               |
+| **US1 (P1, MVP)**          | 11 (T007-T015b — T013a/T015a/T015b 추가, 기존 T015 → T015a/b로 분할)                        |
+| **US2 (P2)**               | 3 (T016-T018, manual QA)                                                                    |
+| **US3 (P2)**               | 10 (T019-T028)                                                                              |
+| **Polish**                 | 8 (T029-T036)                                                                               |
+| **Parallel opportunities** | US1 어댑터 3종 + 테스트 3종, T015a⫷T015b, US3 deprecation 9건, Polish 검증 3종              |
+| **MVP scope**              | T001~T015b + T029~T032 (≈22 tasks)                                                          |
+| **Estimated effort**       | 본격 코드 변경은 T010~T013a (5 files), loading/error.tsx 2 files, 나머지는 주석·테스트·검증 |

--- a/src/app/meet/[meetingId]/edit/date/page.tsx
+++ b/src/app/meet/[meetingId]/edit/date/page.tsx
@@ -1,6 +1,8 @@
-import { type Metadata, type ResolvingMetadata } from 'next';
+import { type Metadata } from 'next';
 
+import { getMeetingById } from '@/entities/meet/api/getMeetingById';
 import ParticipantEditDatePage from '@/features/participant-edit-date/ui/ParticipantEditDatePage';
+import ParticipantEditTimeSlotPage from '@/features/participant-register-time-slot/ui/ParticipantEditTimeSlotPage';
 
 interface PageProps {
   params: Promise<{
@@ -8,10 +10,9 @@ interface PageProps {
   }>;
 }
 
-export async function generateMetadata(
-  { params }: PageProps,
-  parent: ResolvingMetadata,
-): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
   const { meetingId } = await params;
   return {
     title: `일정 수정하기 - ${meetingId}`,
@@ -21,5 +22,18 @@ export async function generateMetadata(
 export default async function Page({ params }: PageProps) {
   const { meetingId } = await params;
 
-  return <ParticipantEditDatePage meetingId={meetingId} />;
+  // timeRange 유무로 입력 UI 분기 (register/date 와 동일 정책)
+  let hasTimeRange = false;
+  try {
+    const meeting = await getMeetingById(meetingId);
+    hasTimeRange = Boolean(meeting.timeRange);
+  } catch {
+    // fetch 실패 시 캘린더로 fallback.
+  }
+
+  return hasTimeRange ? (
+    <ParticipantEditTimeSlotPage meetingId={meetingId} />
+  ) : (
+    <ParticipantEditDatePage meetingId={meetingId} />
+  );
 }

--- a/src/app/meet/[meetingId]/error.tsx
+++ b/src/app/meet/[meetingId]/error.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import Button from '@/shared/ui/button/Button';
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function Error({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    console.error('[/meet/[meetingId]] error:', error);
+  }, [error]);
+
+  return (
+    <div className='min-h-screen-safe flex flex-col items-center justify-center bg-white px-5'>
+      <div className='flex flex-col items-center gap-3 text-center'>
+        <p className='text-title-4 font-bold text-gray-900'>
+          모임을 불러오지 못했어요
+        </p>
+        <p className='text-body-4 text-text-secondary'>
+          잠시 후 다시 시도해주세요.
+        </p>
+      </div>
+      <div className='mt-6 w-full max-w-xs'>
+        <Button onClick={() => reset()} fullWidth>
+          다시 시도
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/meet/[meetingId]/loading.tsx
+++ b/src/app/meet/[meetingId]/loading.tsx
@@ -1,0 +1,16 @@
+export default function Loading() {
+  return (
+    <div className='min-h-screen-safe flex flex-col bg-white pt-14 pb-25'>
+      <div className='fixed top-0 right-0 left-0 z-50 mx-auto h-14 w-full max-w-screen-sm bg-white' />
+      <div className='flex-1 px-5 py-4'>
+        <div className='mb-4 h-8 w-40 animate-pulse rounded bg-gray-100' />
+        <div className='flex flex-col gap-3'>
+          <div className='h-20 animate-pulse rounded-lg bg-gray-100' />
+          <div className='h-20 animate-pulse rounded-lg bg-gray-100' />
+          <div className='h-20 animate-pulse rounded-lg bg-gray-100' />
+        </div>
+      </div>
+      <div className='fixed right-0 bottom-0 left-0 z-50 mx-auto h-20 w-full max-w-screen-sm bg-white' />
+    </div>
+  );
+}

--- a/src/app/meet/[meetingId]/page.tsx
+++ b/src/app/meet/[meetingId]/page.tsx
@@ -1,12 +1,18 @@
+import { HTTPError } from 'ky';
 import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 
 import { getMeetingById } from '@/entities/meet/api/getMeetingById';
 import { type MeetResponse } from '@/entities/meet/dto/meet.dto';
-import { generateMockVoteTimeSlotStat } from '@/entities/voteTimeSlotStat/lib/mock';
+import { toMeetingVoteSnapshot } from '@/entities/meet/lib/toMeetingVoteSnapshot';
+import { buildVoteDateStat } from '@/entities/voteDateStat/lib/buildVoteDateStat';
+import { buildVoteTimeSlotStat } from '@/entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat';
 import MeetResultTablePage from '@/features/meet-result-table/ui/MeetResultTablePage';
 import type { MeetingVoteSnapshot } from '@/features/vote-rank-cards/lib/types';
 import { BASE_URL } from '@/shared/config/constants';
 import { END_HOUR, START_HOUR, TOTAL_SLOTS } from '@/shared/config/timeSlot';
+import { Header } from '@/shared/ui/header/Header';
+import { VoteResultDataView } from '@/widgets/vote-result/ui/VoteResultDataView';
 
 import ParticipantHeader from './ParticipantHeader';
 import { VoteActionButtons } from './VoteActionButtons';
@@ -52,6 +58,13 @@ export async function generateMetadata({
   }
 }
 
+/**
+ * @deprecated [#73, 2026-05-07] 백엔드 API 연동으로 mock 시드 기반 snapshot 생성 불필요.
+ * Replacement: `toMeetingVoteSnapshot` (entities/meet/lib/) + `buildVoteTimeSlotStat` (entities/voteTimeSlotStat/lib/)
+ * Removal target: 별도 정리 PR (specs/feat/073-vote-rank-cards-api/plan.md TODO-9 참조).
+ *
+ * 아래의 `hashSeed`, `mulberry32`, `VISUAL_POOL_SIZE`, `VISUAL_NAMES`, `buildMockSnapshot` 모두 운영 코드 경로에서 호출 0개. 보존만.
+ */
 function hashSeed(input: string): number {
   let hash = 0;
   for (let i = 0; i < input.length; i++) {
@@ -84,6 +97,11 @@ const VISUAL_NAMES = [
   '두쫀쿠',
 ];
 
+/**
+ * @deprecated [#73, 2026-05-07] mock 시드 snapshot 생성기.
+ * Replacement: `toMeetingVoteSnapshot` (entities/meet/lib/)
+ * Removal target: 별도 정리 PR.
+ */
 function buildMockSnapshot(meetingData: MeetResponse): MeetingVoteSnapshot {
   const sortedDates = [...meetingData.dates].sort();
   const rand = mulberry32(hashSeed(meetingData.id));
@@ -119,14 +137,57 @@ function buildMockSnapshot(meetingData: MeetResponse): MeetingVoteSnapshot {
 
 export default async function ResultPage({ params }: PageProps) {
   const { meetingId } = await params;
-  const meetingData = await getMeetingById(meetingId);
 
+  let meetingData: MeetResponse;
+  try {
+    meetingData = await getMeetingById(meetingId);
+  } catch (e) {
+    // 진짜 404 (모임 없음) 만 notFound() 처리.
+    // zod 검증 실패·5xx·네트워크 오류는 그대로 throw해서 error.tsx 가 reset CTA를 노출하도록 함.
+    if (e instanceof HTTPError && e.response.status === 404) {
+      notFound();
+    }
+    throw e;
+  }
+
+  const hasTimeRange = Boolean(meetingData.timeRange);
+
+  if (hasTimeRange) {
+    return (
+      <div className='min-h-screen-safe flex flex-col bg-white pt-14 pb-25'>
+        <div className='fixed top-0 right-0 left-0 z-50 mx-auto w-full max-w-screen-sm bg-white'>
+          <ParticipantHeader
+            title={`${meetingData.hostName}님이 초대한 ${meetingData.title}`}
+            url={`${BASE_URL}/meet/${meetingId}`}
+            className='bg-white'
+          />
+        </div>
+
+        <MeetResultTablePage
+          slotStat={buildVoteTimeSlotStat(meetingData)}
+          snapshot={toMeetingVoteSnapshot(meetingData)}
+        />
+
+        <VoteActionButtons meetingId={meetingId} />
+      </div>
+    );
+  }
+
+  // timeRange 없는 모임 → 2026-04-29 이전 화면 형태 그대로 복원
+  // (Header + VoteResultDataView 조립, bg-gray-50)
   const sortedDates = [...meetingData.dates].sort();
-  const slotStat = generateMockVoteTimeSlotStat(meetingId, sortedDates);
-  const snapshot = buildMockSnapshot(meetingData);
+  const openRange = {
+    start: sortedDates[0],
+    end: sortedDates[sortedDates.length - 1],
+  };
+  const participantNames = meetingData.participants.map((p) => p.name);
+  const koreaTime = new Date(
+    new Date().toLocaleString('en-US', { timeZone: 'Asia/Seoul' }),
+  );
+  const standardTime = `${koreaTime.getHours().toString().padStart(2, '0')}:${koreaTime.getMinutes().toString().padStart(2, '0')}`;
 
   return (
-    <div className='min-h-screen-safe flex flex-col bg-white pt-14 pb-25'>
+    <div className='min-h-screen-safe flex flex-col bg-gray-50 pt-14 pb-25'>
       <div className='fixed top-0 right-0 left-0 z-50 mx-auto w-full max-w-screen-sm bg-white'>
         <ParticipantHeader
           title={`${meetingData.hostName}님이 초대한 ${meetingData.title}`}
@@ -135,7 +196,16 @@ export default async function ResultPage({ params }: PageProps) {
         />
       </div>
 
-      <MeetResultTablePage slotStat={slotStat} snapshot={snapshot} />
+      <Header
+        voteCount={meetingData.participants.length}
+        standardTime={standardTime}
+      />
+
+      <VoteResultDataView
+        participantNames={participantNames}
+        openRange={openRange}
+        stats={buildVoteDateStat(meetingData)}
+      />
 
       <VoteActionButtons meetingId={meetingId} />
     </div>

--- a/src/app/meet/[meetingId]/register/date/page.tsx
+++ b/src/app/meet/[meetingId]/register/date/page.tsx
@@ -1,6 +1,8 @@
-import { type Metadata, type ResolvingMetadata } from 'next';
+import { type Metadata } from 'next';
 
+import { getMeetingById } from '@/entities/meet/api/getMeetingById';
 import ParticipantRegisterDatePage from '@/features/participant-register-date/ui/ParticipantRegisterDatePage';
+import ParticipantRegisterTimeSlotPage from '@/features/participant-register-time-slot/ui/ParticipantRegisterTimeSlotPage';
 
 interface PageProps {
   params: Promise<{
@@ -8,10 +10,9 @@ interface PageProps {
   }>;
 }
 
-export async function generateMetadata(
-  { params }: PageProps,
-  parent: ResolvingMetadata,
-): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
   const { meetingId } = await params;
   return {
     title: `일정 선택하기 - ${meetingId}`,
@@ -21,5 +22,20 @@ export async function generateMetadata(
 export default async function Page({ params }: PageProps) {
   const { meetingId } = await params;
 
-  return <ParticipantRegisterDatePage meetingId={meetingId} />;
+  // timeRange 유무로 입력 UI 분기:
+  // - 시간 모임 → 30분 슬롯 그리드 (드래그 선택)
+  // - 날짜 모임 → 캘린더 (4-29 이전 형태)
+  let hasTimeRange = false;
+  try {
+    const meeting = await getMeetingById(meetingId);
+    hasTimeRange = Boolean(meeting.timeRange);
+  } catch {
+    // fetch 실패 시 캘린더로 fallback. 클라이언트 컴포넌트에서 다시 fetch + 에러 처리.
+  }
+
+  return hasTimeRange ? (
+    <ParticipantRegisterTimeSlotPage meetingId={meetingId} />
+  ) : (
+    <ParticipantRegisterDatePage meetingId={meetingId} />
+  );
 }

--- a/src/app/test/vote-rank-cards/page.tsx
+++ b/src/app/test/vote-rank-cards/page.tsx
@@ -1,3 +1,8 @@
+/**
+ * @deprecated [#73, 2026-05-07] 개발용 라우트. 운영 결과 페이지는 `/meet/[meetingId]` 사용.
+ * 시각 회귀 검증은 Storybook(`Features/VoteRankCards/*`) 으로 충분.
+ * Removal target: 별도 정리 PR (specs/feat/073-vote-rank-cards-api/plan.md TODO-9 참조).
+ */
 import { mockMeetingVoteSnapshot } from '@/features/vote-rank-cards/lib/mock';
 import VoteRankCardsPage from '@/features/vote-rank-cards/ui/VoteRankCardsPage';
 

--- a/src/entities/meet/dto/meet.dto.ts
+++ b/src/entities/meet/dto/meet.dto.ts
@@ -51,12 +51,42 @@ export const checkParticipantExistResponseDto = z.object({
 });
 
 /**
+ * 시간 범위 + 슬롯 카운트 스키마 (모임 조회 응답용)
+ * - createMeetRequestDto.timeRange와 달리 slotCount 포함
+ * - 서버는 LocalTime 직렬화로 "HH:mm:ss" / "H:mm" 등 다양한 형태 응답 가능 → "HH:mm" 으로 정규화
+ */
+function normalizeTime(v: string): string {
+  const match = v.match(/^(\d{1,2}):(\d{2})/);
+  if (!match) return v;
+  return `${match[1].padStart(2, '0')}:${match[2]}`;
+}
+
+export const timeRangeWithSlotCountDto = z.object({
+  startTime: z.string().transform(normalizeTime),
+  endTime: z.string().transform(normalizeTime),
+  slotCount: z.number().int().min(1),
+});
+
+/**
+ * 모임 상태 enum
+ */
+export const meetingStatusEnum = z.enum(['VOTING', 'FINALIZED', 'CLOSED']);
+
+/**
  * 참여자 정보 스키마
  */
 export const participantDto = z.object({
   id: z.number(),
   name: z.string(),
-  voteDates: z.array(z.string()),
+  // 서버는 시간 범위 미설정 모임 또는 미투표 참여자에 대해 null을 반환할 수 있음 → 빈 배열로 정규화
+  voteDates: z
+    .array(z.string())
+    .nullable()
+    .transform((v) => v ?? []),
+  voteTimeSlots: z
+    .array(z.array(z.boolean()))
+    .nullable()
+    .transform((v) => v ?? []),
   hasVoted: z.boolean(),
 });
 
@@ -67,9 +97,12 @@ export const meetResponseDto = z.object({
   id: z.string(),
   title: z.string(),
   dates: z.array(z.string()),
+  status: meetingStatusEnum,
+  finalizedDate: z.string().nullable().optional(),
   maxParticipantCount: z.number().nullable(),
   participants: z.array(participantDto),
   hostName: z.string(),
+  timeRange: timeRangeWithSlotCountDto.nullable().optional(),
 });
 
 // ==================== TypeScript Types ====================
@@ -106,3 +139,13 @@ export type Participant = z.infer<typeof participantDto>;
  * 모임 조회 응답 타입
  */
 export type MeetResponse = z.infer<typeof meetResponseDto>;
+
+/**
+ * 시간 범위 + 슬롯 카운트 타입
+ */
+export type TimeRangeWithSlotCount = z.infer<typeof timeRangeWithSlotCountDto>;
+
+/**
+ * 모임 상태 타입
+ */
+export type MeetingStatus = z.infer<typeof meetingStatusEnum>;

--- a/src/entities/meet/dto/vote.dto.ts
+++ b/src/entities/meet/dto/vote.dto.ts
@@ -4,11 +4,14 @@ import { z } from 'zod';
 
 /**
  * 투표 생성/수정 요청 스키마
+ * - voteTimeSlots: 시간 모임 투표용. 차원: dates.length × slotCount.
+ *   날짜 단위 모임에서는 미포함 (undefined).
  */
 export const voteRequestDto = z.object({
   meetingId: z.string(),
   name: z.string(),
   voteDates: z.array(z.string()),
+  voteTimeSlots: z.array(z.array(z.boolean())).optional(),
 });
 
 /**

--- a/src/entities/meet/lib/toMeetingVoteSnapshot.test.ts
+++ b/src/entities/meet/lib/toMeetingVoteSnapshot.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MeetResponse } from '@/entities/meet/dto/meet.dto';
+import { toMeetingVoteSnapshot } from '@/entities/meet/lib/toMeetingVoteSnapshot';
+
+function makeMeet(overrides?: Partial<MeetResponse>): MeetResponse {
+  return {
+    id: 'm1',
+    title: '테스트 모임',
+    dates: ['2026-04-17', '2026-04-18'],
+    status: 'VOTING',
+    finalizedDate: null,
+    maxParticipantCount: 9,
+    hostName: '호스트',
+    timeRange: { startTime: '12:00', endTime: '13:00', slotCount: 2 },
+    participants: [
+      {
+        id: 1,
+        name: 'A',
+        voteDates: ['2026-04-17'],
+        voteTimeSlots: [
+          [true, false],
+          [false, false],
+        ],
+        hasVoted: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('toMeetingVoteSnapshot', () => {
+  it('정상 변환 - timeRange 있는 모임의 모든 필드 매핑', () => {
+    const meet = makeMeet();
+
+    const snapshot = toMeetingVoteSnapshot(meet);
+
+    expect(snapshot.id).toBe('m1');
+    expect(snapshot.title).toBe('테스트 모임');
+    expect(snapshot.dates).toEqual(['2026-04-17', '2026-04-18']);
+    expect(snapshot.status).toBe('VOTING');
+    expect(snapshot.finalizedDate).toBeNull();
+    expect(snapshot.maxParticipantCount).toBe(9);
+    expect(snapshot.hostName).toBe('호스트');
+    expect(snapshot.timeRange).toEqual({
+      startTime: '12:00',
+      endTime: '13:00',
+      slotCount: 2,
+    });
+    expect(snapshot.participants).toHaveLength(1);
+    expect(snapshot.participants[0].voteTimeSlots).toEqual([
+      [true, false],
+      [false, false],
+    ]);
+  });
+
+  it('participants가 빈 배열이어도 안전 변환', () => {
+    const snapshot = toMeetingVoteSnapshot(makeMeet({ participants: [] }));
+
+    expect(snapshot.participants).toEqual([]);
+  });
+
+  it('voteTimeSlots 차원이 dates × slotCount보다 작으면 false 패딩', () => {
+    const meet = makeMeet({
+      dates: ['2026-04-17', '2026-04-18'],
+      timeRange: { startTime: '12:00', endTime: '14:00', slotCount: 4 },
+      participants: [
+        {
+          id: 1,
+          name: 'A',
+          voteDates: ['2026-04-17'],
+          voteTimeSlots: [[true]], // 1개 row, 1개 slot만
+          hasVoted: true,
+        },
+      ],
+    });
+
+    const snapshot = toMeetingVoteSnapshot(meet);
+
+    expect(snapshot.participants[0].voteTimeSlots).toHaveLength(2);
+    expect(snapshot.participants[0].voteTimeSlots[0]).toEqual([
+      true,
+      false,
+      false,
+      false,
+    ]);
+    expect(snapshot.participants[0].voteTimeSlots[1]).toEqual([
+      false,
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  it('finalizedDate가 undefined면 null로 정규화', () => {
+    const meet = makeMeet({ finalizedDate: undefined });
+
+    const snapshot = toMeetingVoteSnapshot(meet);
+
+    expect(snapshot.finalizedDate).toBeNull();
+  });
+
+  it('strict 모드 + timeRange null → throw', () => {
+    expect(() =>
+      toMeetingVoteSnapshot(makeMeet({ timeRange: null }), { strict: true }),
+    ).toThrow(/timeRange is required/);
+  });
+
+  it('strict=false 모드 + timeRange null → fallback timeRange로 변환', () => {
+    const snapshot = toMeetingVoteSnapshot(makeMeet({ timeRange: null }), {
+      strict: false,
+    });
+
+    expect(snapshot.timeRange.slotCount).toBe(0);
+  });
+
+  it('dates 와 voteTimeSlots 매핑은 server 응답 순서를 그대로 유지', () => {
+    // 어댑터는 dates 순서를 변경하지 않는다 (server 가 정렬 응답한다는 컨벤션 신뢰).
+    const snapshot = toMeetingVoteSnapshot(
+      makeMeet({
+        dates: ['2026-04-17', '2026-04-18'],
+        timeRange: { startTime: '12:00', endTime: '13:00', slotCount: 2 },
+        participants: [
+          {
+            id: 1,
+            name: 'A',
+            voteDates: ['2026-04-17'],
+            voteTimeSlots: [
+              [true, false], // 04-17
+              [false, true], // 04-18
+            ],
+            hasVoted: true,
+          },
+        ],
+      }),
+    );
+
+    expect(snapshot.dates).toEqual(['2026-04-17', '2026-04-18']);
+    expect(snapshot.participants[0].voteTimeSlots).toEqual([
+      [true, false],
+      [false, true],
+    ]);
+  });
+});

--- a/src/entities/meet/lib/toMeetingVoteSnapshot.ts
+++ b/src/entities/meet/lib/toMeetingVoteSnapshot.ts
@@ -1,0 +1,76 @@
+import type { MeetResponse } from '@/entities/meet/dto/meet.dto';
+// FSD 위반 carry-over: `MeetingVoteSnapshot` 타입은 `vote-rank-cards/lib/types` 에 정의돼 있어
+// entities → features 역방향 의존이 발생한다. 본 작업(#73) 범위에서 타입 이전은 보류하고,
+// 별도 정리 PR(specs/feat/073-vote-rank-cards-api/plan.md TODO-8)에서 `entities/meet/dto/`로 이전 예정.
+import type { MeetingVoteSnapshot } from '@/features/vote-rank-cards/lib/types';
+
+export interface ToMeetingVoteSnapshotOptions {
+  /**
+   * timeRange 가 누락된 입력에 대해 throw 할지 여부.
+   * - true (default): 시간 모임만 처리. 호출자가 분기 책임.
+   * - false: 의미 없는 fallback timeRange 로 변환 (운영 코드 사용 권장 안 함).
+   */
+  strict?: boolean;
+}
+
+/**
+ * 서버 raw `voteTimeSlots` 를 고정 차원(dates × slotCount) 으로 정규화.
+ * - 입력 row 길이가 expectedSlots 보다 짧으면 false 패딩, 길면 잘라냄.
+ * - dates 와 voteTimeSlots row 의 인덱스 매핑은 server 응답 순서를 그대로 신뢰
+ *   (모임 생성 시 클라가 정렬된 dates 를 보내고 server 가 그 순서로 저장·응답한다는 컨벤션).
+ */
+function normalizeVoteTimeSlots(
+  raw: boolean[][] | undefined | null,
+  expectedDates: number,
+  expectedSlots: number,
+): boolean[][] {
+  return Array.from({ length: expectedDates }, (_, dateIndex) => {
+    const row = raw?.[dateIndex] ?? [];
+    return Array.from({ length: expectedSlots }, (_, slotIndex) =>
+      Boolean(row[slotIndex]),
+    );
+  });
+}
+
+export function toMeetingVoteSnapshot(
+  meet: MeetResponse,
+  options: ToMeetingVoteSnapshotOptions = {},
+): MeetingVoteSnapshot {
+  const strict = options.strict ?? true;
+
+  if (!meet.timeRange) {
+    if (strict) {
+      throw new Error(
+        'toMeetingVoteSnapshot: timeRange is required. timeRange가 없는 모임은 캘린더 뷰로 분기되어야 함.',
+      );
+    }
+  }
+
+  const slotCount = meet.timeRange?.slotCount ?? 0;
+
+  return {
+    id: meet.id,
+    title: meet.title,
+    dates: meet.dates,
+    status: meet.status,
+    finalizedDate: meet.finalizedDate ?? null,
+    maxParticipantCount: meet.maxParticipantCount ?? 0,
+    hostName: meet.hostName,
+    timeRange: meet.timeRange ?? {
+      startTime: '00:00',
+      endTime: '00:00',
+      slotCount: 0,
+    },
+    participants: meet.participants.map((participant) => ({
+      id: participant.id,
+      name: participant.name,
+      voteDates: participant.voteDates,
+      voteTimeSlots: normalizeVoteTimeSlots(
+        participant.voteTimeSlots,
+        meet.dates.length,
+        slotCount,
+      ),
+      hasVoted: participant.hasVoted,
+    })),
+  };
+}

--- a/src/entities/voteDateStat/api/fetchVoteDateStat.ts
+++ b/src/entities/voteDateStat/api/fetchVoteDateStat.ts
@@ -1,11 +1,14 @@
 import { VoteDateStat } from '../dto/voteDateStat.dto';
 
-// TODO: 실제 API 스펙이 정해지면 이 파일에서 구현합니다.
-
 export type FetchVoteDateStatParams = {
   meetingId: string;
 };
 
+/**
+ * @deprecated [#73, 2026-05-07] sandbox swagger 확인 결과 서버에 날짜 집계 전용 엔드포인트 부재.
+ * Replacement: `buildVoteDateStat` (entities/voteDateStat/lib/) — `getMeetingById` 응답을 클라에서 집계.
+ * Removal target: 별도 정리 PR (specs/feat/073-vote-rank-cards-api/plan.md TODO-9 참조).
+ */
 export async function fetchVoteDateStat(
   _params: FetchVoteDateStatParams,
 ): Promise<VoteDateStat[]> {

--- a/src/entities/voteDateStat/lib/buildVoteDateStat.test.ts
+++ b/src/entities/voteDateStat/lib/buildVoteDateStat.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MeetResponse } from '@/entities/meet/dto/meet.dto';
+import { buildVoteDateStat } from '@/entities/voteDateStat/lib/buildVoteDateStat';
+
+function makeMeet(overrides?: Partial<MeetResponse>): MeetResponse {
+  return {
+    id: 'm1',
+    title: '테스트',
+    dates: ['2026-04-17', '2026-04-18'],
+    status: 'VOTING',
+    finalizedDate: null,
+    maxParticipantCount: 9,
+    hostName: '호스트',
+    timeRange: null,
+    participants: [],
+    ...overrides,
+  };
+}
+
+describe('buildVoteDateStat', () => {
+  it('각 date마다 can/cannot 분류', () => {
+    const stats = buildVoteDateStat(
+      makeMeet({
+        dates: ['2026-04-17', '2026-04-18'],
+        participants: [
+          {
+            id: 1,
+            name: 'A',
+            voteDates: ['2026-04-17'],
+            voteTimeSlots: [],
+            hasVoted: true,
+          },
+          {
+            id: 2,
+            name: 'B',
+            voteDates: ['2026-04-18'],
+            voteTimeSlots: [],
+            hasVoted: true,
+          },
+        ],
+      }),
+    );
+
+    expect(stats).toHaveLength(2);
+    expect(stats[0]).toEqual({
+      date: '2026-04-17',
+      can: [{ id: '1', name: 'A' }],
+      cannot: [{ id: '2', name: 'B' }],
+    });
+    expect(stats[1]).toEqual({
+      date: '2026-04-18',
+      can: [{ id: '2', name: 'B' }],
+      cannot: [{ id: '1', name: 'A' }],
+    });
+  });
+
+  it('hasVoted=false인 참여자는 분류에서 제외', () => {
+    const stats = buildVoteDateStat(
+      makeMeet({
+        dates: ['2026-04-17'],
+        participants: [
+          {
+            id: 1,
+            name: '투표함',
+            voteDates: ['2026-04-17'],
+            voteTimeSlots: [],
+            hasVoted: true,
+          },
+          {
+            id: 2,
+            name: '투표안함',
+            voteDates: [],
+            voteTimeSlots: [],
+            hasVoted: false,
+          },
+        ],
+      }),
+    );
+
+    expect(stats[0].can).toEqual([{ id: '1', name: '투표함' }]);
+    expect(stats[0].cannot).toEqual([]);
+  });
+
+  it('dates 순서는 server 응답 순서를 그대로 유지', () => {
+    // 어댑터는 별도 정렬을 적용하지 않는다 (server 가 정렬 응답한다는 컨벤션 신뢰).
+    const stats = buildVoteDateStat(
+      makeMeet({ dates: ['2026-04-17', '2026-04-19', '2026-04-20'] }),
+    );
+
+    expect(stats.map((s) => s.date)).toEqual([
+      '2026-04-17',
+      '2026-04-19',
+      '2026-04-20',
+    ]);
+  });
+
+  it('모든 참여자 voteDates=[] - 모든 날짜에서 cannot으로 분류', () => {
+    const stats = buildVoteDateStat(
+      makeMeet({
+        dates: ['2026-04-17'],
+        participants: [
+          {
+            id: 1,
+            name: 'A',
+            voteDates: [],
+            voteTimeSlots: [],
+            hasVoted: true,
+          },
+        ],
+      }),
+    );
+
+    expect(stats[0].can).toEqual([]);
+    expect(stats[0].cannot).toEqual([{ id: '1', name: 'A' }]);
+  });
+
+  it('participants 빈 배열', () => {
+    const stats = buildVoteDateStat(
+      makeMeet({ dates: ['2026-04-17'], participants: [] }),
+    );
+
+    expect(stats).toEqual([{ date: '2026-04-17', can: [], cannot: [] }]);
+  });
+});

--- a/src/entities/voteDateStat/lib/buildVoteDateStat.ts
+++ b/src/entities/voteDateStat/lib/buildVoteDateStat.ts
@@ -1,0 +1,31 @@
+import type { MeetResponse } from '@/entities/meet/dto/meet.dto';
+import type { VoteDateStat } from '@/entities/voteDateStat/dto/voteDateStat.dto';
+import type { Person } from '@/shared/types/common';
+
+/**
+ * `MeetResponse` 의 raw 투표 데이터를 날짜 단위 집계(`VoteDateStat[]`) 로 변환.
+ *
+ * dates 순서는 server 응답을 그대로 신뢰한다 (모임 생성 시 클라가 정렬된 dates 를 보내고
+ * server 가 그 순서로 저장·응답한다는 컨벤션. buildVoteTimeSlotStat / toMeetingVoteSnapshot
+ * 과 동일 정책).
+ */
+export function buildVoteDateStat(meet: MeetResponse): VoteDateStat[] {
+  const votedParticipants = meet.participants.filter((p) => p.hasVoted);
+
+  return meet.dates.map((date) => {
+    const can: Person[] = [];
+    const cannot: Person[] = [];
+    for (const participant of votedParticipants) {
+      const person: Person = {
+        id: String(participant.id),
+        name: participant.name,
+      };
+      if (participant.voteDates.includes(date)) {
+        can.push(person);
+      } else {
+        cannot.push(person);
+      }
+    }
+    return { date, can, cannot };
+  });
+}

--- a/src/entities/voteTimeSlotStat/api/fetchVoteTimeSlotStat.ts
+++ b/src/entities/voteTimeSlotStat/api/fetchVoteTimeSlotStat.ts
@@ -1,0 +1,16 @@
+import { type VoteTimeSlotStat } from '../dto/voteTimeSlotStat.dto';
+
+export type FetchVoteTimeSlotStatParams = {
+  meetingId: string;
+};
+
+/**
+ * @deprecated [#73, 2026-05-07] sandbox swagger 확인 결과 서버에 시간대 집계 전용 엔드포인트 부재.
+ * Replacement: `buildVoteTimeSlotStat` (entities/voteTimeSlotStat/lib/) — `getMeetingById` 응답을 클라에서 집계.
+ * Removal target: 별도 정리 PR (specs/feat/073-vote-rank-cards-api/plan.md TODO-9 참조).
+ */
+export async function fetchVoteTimeSlotStat(
+  _params: FetchVoteTimeSlotStatParams,
+): Promise<VoteTimeSlotStat> {
+  throw new Error('fetchVoteTimeSlotStat is not implemented yet');
+}

--- a/src/entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat.test.ts
+++ b/src/entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MeetResponse } from '@/entities/meet/dto/meet.dto';
+import { buildVoteTimeSlotStat } from '@/entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat';
+
+function makeMeet(overrides?: Partial<MeetResponse>): MeetResponse {
+  return {
+    id: 'm1',
+    title: '테스트',
+    dates: ['2026-04-17', '2026-04-18'],
+    status: 'VOTING',
+    finalizedDate: null,
+    maxParticipantCount: 9,
+    hostName: '호스트',
+    timeRange: { startTime: '12:00', endTime: '13:00', slotCount: 2 },
+    participants: [],
+    ...overrides,
+  };
+}
+
+describe('buildVoteTimeSlotStat', () => {
+  it('cells 개수 = dates × slotCount', () => {
+    const stat = buildVoteTimeSlotStat(
+      makeMeet({
+        dates: ['2026-04-17', '2026-04-18', '2026-04-19'],
+        timeRange: { startTime: '12:00', endTime: '14:00', slotCount: 4 },
+      }),
+    );
+
+    expect(stat.cells).toHaveLength(12); // 3 × 4
+  });
+
+  it('hasVoted=false인 참여자는 집계·allParticipants에서 제외', () => {
+    const meet = makeMeet({
+      participants: [
+        {
+          id: 1,
+          name: '투표함',
+          voteDates: ['2026-04-17'],
+          voteTimeSlots: [
+            [true, false],
+            [false, false],
+          ],
+          hasVoted: true,
+        },
+        {
+          id: 2,
+          name: '투표안함',
+          voteDates: [],
+          voteTimeSlots: [],
+          hasVoted: false,
+        },
+      ],
+    });
+
+    const stat = buildVoteTimeSlotStat(meet);
+
+    const cell0 = stat.cells.find(
+      (c) => c.date === '2026-04-17' && c.slotIdx === 0,
+    );
+    expect(cell0?.count).toBe(1);
+    expect(cell0?.participants).toEqual([{ id: 1, name: '투표함' }]);
+    expect(stat.allParticipants).toEqual([{ id: 1, name: '투표함' }]);
+  });
+
+  it('모든 셀 0표 - participants 빈 배열', () => {
+    const stat = buildVoteTimeSlotStat(makeMeet({ participants: [] }));
+
+    expect(stat.cells.every((c) => c.count === 0)).toBe(true);
+    expect(stat.allParticipants).toEqual([]);
+  });
+
+  it('slotCount=1 단일 셀', () => {
+    const stat = buildVoteTimeSlotStat(
+      makeMeet({
+        dates: ['2026-04-17'],
+        timeRange: { startTime: '12:00', endTime: '12:30', slotCount: 1 },
+        participants: [
+          {
+            id: 1,
+            name: 'A',
+            voteDates: ['2026-04-17'],
+            voteTimeSlots: [[true]],
+            hasVoted: true,
+          },
+        ],
+      }),
+    );
+
+    expect(stat.cells).toHaveLength(1);
+    expect(stat.cells[0]).toEqual({
+      date: '2026-04-17',
+      slotIdx: 0,
+      count: 1,
+      participants: [{ id: 1, name: 'A' }],
+    });
+  });
+
+  it('timeRange null → throw', () => {
+    expect(() => buildVoteTimeSlotStat(makeMeet({ timeRange: null }))).toThrow(
+      /timeRange is required/,
+    );
+  });
+
+  it('voteTimeSlots 차원이 부족한 참여자도 안전 처리', () => {
+    const stat = buildVoteTimeSlotStat(
+      makeMeet({
+        timeRange: { startTime: '12:00', endTime: '13:00', slotCount: 2 },
+        participants: [
+          {
+            id: 1,
+            name: 'A',
+            voteDates: ['2026-04-17'],
+            voteTimeSlots: [[true]], // 차원 mismatch
+            hasVoted: true,
+          },
+        ],
+      }),
+    );
+
+    expect(stat.cells.find((c) => c.slotIdx === 0)?.count).toBe(1);
+    expect(stat.cells.find((c) => c.slotIdx === 1)?.count).toBe(0);
+  });
+
+  it('cells 의 date 와 voteTimeSlots row 매핑은 server 응답 순서를 그대로 유지', () => {
+    // 어댑터는 dates 순서를 변경하지 않는다.
+    // (server 가 정렬된 dates 를 응답한다는 컨벤션 신뢰)
+    const stat = buildVoteTimeSlotStat(
+      makeMeet({
+        dates: ['2026-04-17', '2026-04-18'],
+        timeRange: { startTime: '12:00', endTime: '13:00', slotCount: 2 },
+        participants: [
+          {
+            id: 1,
+            name: 'A',
+            voteDates: ['2026-04-17'],
+            voteTimeSlots: [
+              [true, false], // 04-17
+              [false, true], // 04-18
+            ],
+            hasVoted: true,
+          },
+        ],
+      }),
+    );
+
+    expect(stat.dates).toEqual(['2026-04-17', '2026-04-18']);
+    expect(
+      stat.cells.find((c) => c.date === '2026-04-17' && c.slotIdx === 0)?.count,
+    ).toBe(1);
+    expect(
+      stat.cells.find((c) => c.date === '2026-04-18' && c.slotIdx === 1)?.count,
+    ).toBe(1);
+  });
+});

--- a/src/entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat.ts
+++ b/src/entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat.ts
@@ -1,0 +1,48 @@
+import type { MeetResponse } from '@/entities/meet/dto/meet.dto';
+import type {
+  TimeSlotCell,
+  VoteTimeSlotStat,
+} from '@/entities/voteTimeSlotStat/dto/voteTimeSlotStat.dto';
+
+/**
+ * `MeetResponse` 의 raw 투표 데이터를 시간대 셀 집계(`VoteTimeSlotStat`) 로 변환.
+ *
+ * dates 와 voteTimeSlots row 의 인덱스 매핑은 server 응답 순서를 그대로 신뢰한다
+ * (모임 생성 시 클라가 정렬된 dates 를 보내고 server 가 그 순서로 저장·응답).
+ */
+export function buildVoteTimeSlotStat(meet: MeetResponse): VoteTimeSlotStat {
+  if (!meet.timeRange) {
+    throw new Error(
+      'buildVoteTimeSlotStat: timeRange is required. timeRange가 없는 모임은 별도 buildVoteDateStat 어댑터를 사용해야 함.',
+    );
+  }
+
+  const slotCount = meet.timeRange.slotCount;
+  const votedParticipants = meet.participants.filter((p) => p.hasVoted);
+
+  const cells: TimeSlotCell[] = [];
+  for (let dateIndex = 0; dateIndex < meet.dates.length; dateIndex += 1) {
+    const date = meet.dates[dateIndex];
+    for (let slotIdx = 0; slotIdx < slotCount; slotIdx += 1) {
+      const ablePeople = votedParticipants
+        .filter((p) => Boolean(p.voteTimeSlots?.[dateIndex]?.[slotIdx]))
+        .map((p) => ({ id: p.id, name: p.name }));
+      cells.push({
+        date,
+        slotIdx,
+        count: ablePeople.length,
+        participants: ablePeople,
+      });
+    }
+  }
+
+  return {
+    meetingId: meet.id,
+    dates: meet.dates,
+    cells,
+    allParticipants: votedParticipants.map((p) => ({
+      id: p.id,
+      name: p.name,
+    })),
+  };
+}

--- a/src/entities/voteTimeSlotStat/lib/mock.ts
+++ b/src/entities/voteTimeSlotStat/lib/mock.ts
@@ -41,6 +41,11 @@ const VISUAL_NAMES = [
   '두쫀쿠',
 ];
 
+/**
+ * @deprecated [#73, 2026-05-07] mock 시드 기반 시간대 집계 생성기. 운영 라우트는 `buildVoteTimeSlotStat` 사용.
+ * Replacement: `buildVoteTimeSlotStat` (entities/voteTimeSlotStat/lib/) — `MeetResponse` 입력으로 실 데이터 집계.
+ * Removal target: 별도 정리 PR (specs/feat/073-vote-rank-cards-api/plan.md TODO-9 참조).
+ */
 export function generateMockVoteTimeSlotStat(
   meetingId: string,
   dates: string[],

--- a/src/features/meet-create-date/model/useDateSelect.ts
+++ b/src/features/meet-create-date/model/useDateSelect.ts
@@ -8,11 +8,27 @@ import { updateVote } from '@/entities/meet/api/updateVote';
 import type { TimeRangePayload } from '@/entities/meet/dto/meet.dto';
 import { trackEvent } from '@/shared/lib/amplitude';
 
+/** "HH:mm" → 자정으로부터의 분 */
+function timeToMinutes(t: string): number {
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + m;
+}
+
+/** timeRange 의 30분 단위 슬롯 수 (모임 생성 시 30분 단위 강제이므로 정수). */
+function calcSlotCount(timeRange: TimeRangePayload): number {
+  return (
+    (timeToMinutes(timeRange.endTime) - timeToMinutes(timeRange.startTime)) / 30
+  );
+}
+
 export function useDateSelect(hostName: string, meetingName: string) {
   const router = useRouter();
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
   const [createdMeetingId, setCreatedMeetingId] = useState<string | null>(null);
   const [selectedDates, setSelectedDates] = useState<string[]>([]);
+  const [createdTimeRange, setCreatedTimeRange] = useState<
+    TimeRangePayload | undefined
+  >(undefined);
 
   const handleBack = () => {
     const params = new URLSearchParams({
@@ -49,6 +65,7 @@ export function useDateSelect(hostName: string, meetingName: string) {
       console.log('모임 생성 완료:', response);
       setCreatedMeetingId(response.id);
       setSelectedDates(formattedDates);
+      setCreatedTimeRange(timeRangePayload);
       setIsBottomSheetOpen(true);
     } catch (error) {
       console.error('모임 생성 실패:', error);
@@ -78,11 +95,20 @@ export function useDateSelect(hostName: string, meetingName: string) {
       selection: 'all_available',
     });
     if (createdMeetingId && selectedDates.length > 0) {
+      // 시간 모임이면 모든 날짜 × 모든 슬롯 = true 인 voteTimeSlots 도 함께 전달.
+      // (날짜 모임이면 voteTimeSlots 미포함 — voteRequestDto.voteTimeSlots 가 optional)
+      const voteTimeSlots = createdTimeRange
+        ? selectedDates.map(() =>
+            Array(calcSlotCount(createdTimeRange)).fill(true),
+          )
+        : undefined;
+
       try {
         await updateVote({
           meetingId: createdMeetingId,
           name: hostName,
           voteDates: selectedDates,
+          voteTimeSlots,
         });
         console.log('주최자 투표 완료');
         // 캐시 무효화를 위해 전체 페이지 새로고침으로 이동

--- a/src/features/meet-result-table/model/useSelectedCell.ts
+++ b/src/features/meet-result-table/model/useSelectedCell.ts
@@ -3,9 +3,14 @@
 import { useCallback, useState } from 'react';
 
 export type SelectedCell = { date: string; slotIdx: number } | null;
+export type CardPosition = 'top' | 'bottom';
+export type CollapsedSide = 'left' | 'right';
 
 export function useSelectedCell() {
   const [selected, setSelected] = useState<SelectedCell>(null);
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [position, setPosition] = useState<CardPosition>('top');
+  const [collapsedSide, setCollapsedSide] = useState<CollapsedSide>('right');
 
   const select = useCallback((date: string, slotIdx: number) => {
     setSelected((prev) => {
@@ -14,15 +19,32 @@ export function useSelectedCell() {
       }
       return { date, slotIdx };
     });
+    setIsExpanded(true);
   }, []);
 
   const close = useCallback(() => {
     setSelected(null);
+    setIsExpanded(true);
+    setPosition('top');
+    setCollapsedSide('right');
   }, []);
+
+  const collapse = useCallback((side: CollapsedSide) => {
+    setCollapsedSide(side);
+    setIsExpanded(false);
+  }, []);
+  const expand = useCallback(() => setIsExpanded(true), []);
+  const moveTo = useCallback((next: CardPosition) => setPosition(next), []);
 
   return {
     selected,
+    isExpanded,
+    position,
+    collapsedSide,
     select,
     close,
+    collapse,
+    expand,
+    moveTo,
   };
 }

--- a/src/features/meet-result-table/model/useSelectedCell.ts
+++ b/src/features/meet-result-table/model/useSelectedCell.ts
@@ -3,12 +3,9 @@
 import { useCallback, useState } from 'react';
 
 export type SelectedCell = { date: string; slotIdx: number } | null;
-export type CardPosition = 'top' | 'bottom';
 
 export function useSelectedCell() {
   const [selected, setSelected] = useState<SelectedCell>(null);
-  const [isExpanded, setIsExpanded] = useState(true);
-  const [position, setPosition] = useState<CardPosition>('top');
 
   const select = useCallback((date: string, slotIdx: number) => {
     setSelected((prev) => {
@@ -17,27 +14,15 @@ export function useSelectedCell() {
       }
       return { date, slotIdx };
     });
-    setIsExpanded(true);
   }, []);
 
   const close = useCallback(() => {
     setSelected(null);
-    setIsExpanded(true);
-    setPosition('top');
   }, []);
-
-  const collapse = useCallback(() => setIsExpanded(false), []);
-  const expand = useCallback(() => setIsExpanded(true), []);
-  const moveTo = useCallback((next: CardPosition) => setPosition(next), []);
 
   return {
     selected,
-    isExpanded,
-    position,
     select,
     close,
-    collapse,
-    expand,
-    moveTo,
   };
 }

--- a/src/features/meet-result-table/ui/CellInfoCard.tsx
+++ b/src/features/meet-result-table/ui/CellInfoCard.tsx
@@ -1,26 +1,19 @@
 'use client';
 
-import {
-  type PointerEvent as ReactPointerEvent,
-  useRef,
-  useState,
-} from 'react';
-
 import { type VoteTimeSlotStat } from '@/entities/voteTimeSlotStat/dto/voteTimeSlotStat.dto';
 import { SLOTS_PER_HOUR, START_HOUR } from '@/shared/config/timeSlot';
 import { parseDate } from '@/shared/lib/date';
 import Chip from '@/shared/ui/chip/Chip';
+import Icon from '@/shared/ui/icon/Icon';
 
 import { computeHeatmapIntensity } from '../lib/computeHeatmapIntensity';
 import { cellKey } from '../lib/slotKey';
 import { rankFromOpacity } from '../lib/timeSlotConstants';
-import { type CardPosition, type SelectedCell } from '../model/useSelectedCell';
+import { type SelectedCell } from '../model/useSelectedCell';
 
 const WEEK_KO = ['일', '월', '화', '수', '목', '금', '토'];
-const COLLAPSE_THRESHOLD_PX = 100;
-const SNAP_THRESHOLD_PX = 80;
-const SCREEN_SM_PX = 640; // matches max-w-screen-sm wrapper in ResultTableView
-const CARD_INSET_X_PX = 12; // matches inset-x-3
+const SCREEN_SM_PX = 640;
+const CARD_INSET_X_PX = 12;
 const CARD_MAX_W_PX = SCREEN_SM_PX - CARD_INSET_X_PX * 2;
 
 function formatDate(dateStr: string): string {
@@ -45,50 +38,15 @@ function formatSlotRange(slotIdx: number): string {
 interface CellInfoCardProps {
   slotStat: VoteTimeSlotStat;
   selected: SelectedCell;
-  isExpanded: boolean;
-  position: CardPosition;
   onClose: () => void;
-  onCollapse: () => void;
-  onExpand: () => void;
-  onMoveTo: (position: CardPosition) => void;
 }
 
 export default function CellInfoCard({
   slotStat,
   selected,
-  isExpanded,
-  position,
   onClose,
-  onCollapse,
-  onExpand,
-  onMoveTo,
 }: CellInfoCardProps) {
-  const dragStartRef = useRef<{ x: number; y: number } | null>(null);
-  const [drag, setDrag] = useState({ x: 0, y: 0 });
-
   if (!selected) return null;
-
-  if (!isExpanded) {
-    return (
-      <button
-        type='button'
-        aria-label='카드 펼치기'
-        onClick={onExpand}
-        style={{ right: `max(0px, calc(50vw - ${SCREEN_SM_PX / 2}px))` }}
-        className='fixed top-1/2 z-60 flex h-20 w-7 -translate-y-1/2 items-center justify-center rounded-l-xl bg-gray-700/80 text-white shadow-md backdrop-blur-sm'
-      >
-        <svg width='14' height='14' viewBox='0 0 14 14' fill='none' aria-hidden>
-          <path
-            d='M9 3L5 7l4 4'
-            stroke='currentColor'
-            strokeWidth='1.6'
-            strokeLinecap='round'
-            strokeLinejoin='round'
-          />
-        </svg>
-      </button>
-    );
-  }
 
   const intensityMap = computeHeatmapIntensity(slotStat.cells);
   const key = cellKey(selected.date, selected.slotIdx);
@@ -103,68 +61,13 @@ export default function CellInfoCard({
   const intensity = intensityMap.get(key) ?? null;
   const rank = rankFromOpacity(intensity);
 
-  const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
-    dragStartRef.current = { x: e.clientX, y: e.clientY };
-    try {
-      e.currentTarget.setPointerCapture(e.pointerId);
-    } catch {
-      // synthetic 이벤트나 pointerId 미지원 환경 — capture 없이도 동작
-    }
-  };
-
-  const handlePointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
-    if (!dragStartRef.current) return;
-    setDrag({
-      x: Math.max(0, e.clientX - dragStartRef.current.x),
-      y: e.clientY - dragStartRef.current.y,
-    });
-  };
-
-  const handlePointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
-    if (!dragStartRef.current) return;
-    const dx = Math.max(0, e.clientX - dragStartRef.current.x);
-    const dy = e.clientY - dragStartRef.current.y;
-    dragStartRef.current = null;
-    setDrag({ x: 0, y: 0 });
-
-    // 우측 끝까지 이동 → 수납 우선
-    if (dx > COLLAPSE_THRESHOLD_PX) {
-      onCollapse();
-    } else if (Math.abs(dy) > SNAP_THRESHOLD_PX) {
-      // 상단↔하단 스냅
-      if (dy > 0 && position === 'top') onMoveTo('bottom');
-      else if (dy < 0 && position === 'bottom') onMoveTo('top');
-    }
-
-    try {
-      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
-        e.currentTarget.releasePointerCapture(e.pointerId);
-      }
-    } catch {
-      // ignore
-    }
-  };
-
   return (
     <div
       role='dialog'
       aria-modal='false'
       aria-label='시간 슬롯 상세'
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
-      onPointerCancel={handlePointerUp}
-      style={{
-        transform: `translate(${drag.x}px, ${drag.y}px)`,
-        transition:
-          drag.x === 0 && drag.y === 0
-            ? 'transform 200ms ease-out, top 200ms ease-out, bottom 200ms ease-out'
-            : 'none',
-        maxWidth: CARD_MAX_W_PX,
-      }}
-      className={`fixed inset-x-3 z-60 mx-auto cursor-grab touch-none rounded-2xl border border-gray-100 bg-white p-4 shadow-[0_8px_24px_rgba(0,0,0,0.08)] active:cursor-grabbing ${
-        position === 'top' ? 'top-16' : 'bottom-28'
-      }`}
+      style={{ maxWidth: CARD_MAX_W_PX }}
+      className='fixed inset-x-3 bottom-28 z-60 mx-auto rounded-2xl border border-gray-100 bg-white p-4 shadow-[0_8px_24px_rgba(0,0,0,0.08)]'
     >
       <div className='flex items-center gap-2'>
         {rank !== null && (
@@ -179,7 +82,6 @@ export default function CellInfoCard({
           type='button'
           aria-label='닫기'
           onClick={onClose}
-          onPointerDown={(e) => e.stopPropagation()}
           className='text-text-tertiary hover:text-text-primary'
         >
           <svg width='20' height='20' viewBox='0 0 20 20' fill='none'>
@@ -195,17 +97,13 @@ export default function CellInfoCard({
 
       <hr className='my-3 border-gray-100' />
 
-      <div className='flex items-center gap-1.5'>
-        <span className='bg-primary-default inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] text-white'>
-          ✓
-        </span>
-        <span className='text-primary-default text-[13px] font-semibold'>
-          가능한 사람
-        </span>
+      <div className='text-primary-default flex items-center gap-1'>
+        <Icon name='ic_circle_check_filled' size={16} />
+        <span className='text-[13px] font-semibold'>가능한 사람</span>
       </div>
       <div className='mt-2 flex flex-wrap gap-1.5'>
         {canPeople.length === 0 ? (
-          <span className='text-text-tertiary text-[13px]'>없음</span>
+          <span className='text-text-tertiary text-[13px]'>아무도 없어요</span>
         ) : (
           canPeople.map((p) => (
             <Chip
@@ -219,17 +117,13 @@ export default function CellInfoCard({
         )}
       </div>
 
-      <div className='mt-3 flex items-center gap-1.5'>
-        <span className='inline-flex h-4 w-4 items-center justify-center rounded-full bg-orange-400 text-[10px] text-white'>
-          ✕
-        </span>
-        <span className='text-[13px] font-semibold text-orange-500'>
-          안되는 사람
-        </span>
+      <div className='mt-3 flex items-center gap-1 text-orange-500'>
+        <Icon name='ic_circle_x_filled' size={16} />
+        <span className='text-[13px] font-semibold'>안되는 사람</span>
       </div>
       <div className='mt-2 flex flex-wrap gap-1.5'>
         {cannotPeople.length === 0 ? (
-          <span className='text-text-tertiary text-[13px]'>없음</span>
+          <span className='text-text-tertiary text-[13px]'>모두 가능해요</span>
         ) : (
           cannotPeople.map((p) => (
             <Chip

--- a/src/features/meet-result-table/ui/CellInfoCard.tsx
+++ b/src/features/meet-result-table/ui/CellInfoCard.tsx
@@ -1,5 +1,11 @@
 'use client';
 
+import {
+  type PointerEvent as ReactPointerEvent,
+  useRef,
+  useState,
+} from 'react';
+
 import { type VoteTimeSlotStat } from '@/entities/voteTimeSlotStat/dto/voteTimeSlotStat.dto';
 import { SLOTS_PER_HOUR, START_HOUR } from '@/shared/config/timeSlot';
 import { parseDate } from '@/shared/lib/date';
@@ -9,9 +15,15 @@ import Icon from '@/shared/ui/icon/Icon';
 import { computeHeatmapIntensity } from '../lib/computeHeatmapIntensity';
 import { cellKey } from '../lib/slotKey';
 import { rankFromOpacity } from '../lib/timeSlotConstants';
-import { type SelectedCell } from '../model/useSelectedCell';
+import {
+  type CardPosition,
+  type CollapsedSide,
+  type SelectedCell,
+} from '../model/useSelectedCell';
 
 const WEEK_KO = ['일', '월', '화', '수', '목', '금', '토'];
+const COLLAPSE_THRESHOLD_PX = 100;
+const SNAP_THRESHOLD_PX = 80;
 const SCREEN_SM_PX = 640;
 const CARD_INSET_X_PX = 12;
 const CARD_MAX_W_PX = SCREEN_SM_PX - CARD_INSET_X_PX * 2;
@@ -38,15 +50,63 @@ function formatSlotRange(slotIdx: number): string {
 interface CellInfoCardProps {
   slotStat: VoteTimeSlotStat;
   selected: SelectedCell;
+  isExpanded: boolean;
+  position: CardPosition;
+  collapsedSide: CollapsedSide;
   onClose: () => void;
+  onCollapse: (side: CollapsedSide) => void;
+  onExpand: () => void;
+  onMoveTo: (position: CardPosition) => void;
 }
 
 export default function CellInfoCard({
   slotStat,
   selected,
+  isExpanded,
+  position,
+  collapsedSide,
   onClose,
+  onCollapse,
+  onExpand,
+  onMoveTo,
 }: CellInfoCardProps) {
+  const dragStartRef = useRef<{ x: number; y: number } | null>(null);
+  const [drag, setDrag] = useState({ x: 0, y: 0 });
+
   if (!selected) return null;
+
+  // 수납된 상태 — 마지막 throw 방향 (좌/우) 화면 끝에 작은 화살표 버튼만 노출.
+  if (!isExpanded) {
+    const sideStyle =
+      collapsedSide === 'right'
+        ? { right: `max(0px, calc(50vw - ${SCREEN_SM_PX / 2}px))` }
+        : { left: `max(0px, calc(50vw - ${SCREEN_SM_PX / 2}px))` };
+    const sideRoundedClass =
+      collapsedSide === 'right' ? 'rounded-l-xl' : 'rounded-r-xl';
+    // 우측 수납이면 화살표가 좌측 향함 (`<`), 좌측 수납이면 우측 향함 (`>`).
+    const arrowPath =
+      collapsedSide === 'right' ? 'M9 3L5 7l4 4' : 'M5 3l4 4-4 4';
+
+    return (
+      <button
+        type='button'
+        aria-label='카드 펼치기'
+        onClick={onExpand}
+        style={sideStyle}
+        className={`fixed top-1/2 z-60 flex h-20 w-7 -translate-y-1/2 items-center justify-center bg-gray-700/80 text-white shadow-md backdrop-blur-sm ${sideRoundedClass}`}
+      >
+        <svg width='14' height='14' viewBox='0 0 14 14' fill='none' aria-hidden>
+          <path
+            d={arrowPath}
+            stroke='currentColor'
+            strokeWidth='1.6'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+          />
+        </svg>
+      </button>
+    );
+  }
 
   const intensityMap = computeHeatmapIntensity(slotStat.cells);
   const key = cellKey(selected.date, selected.slotIdx);
@@ -61,13 +121,67 @@ export default function CellInfoCard({
   const intensity = intensityMap.get(key) ?? null;
   const rank = rankFromOpacity(intensity);
 
+  const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    dragStartRef.current = { x: e.clientX, y: e.clientY };
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      // synthetic event 또는 미지원 환경 — capture 없이도 동작
+    }
+  };
+
+  const handlePointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (!dragStartRef.current) return;
+    setDrag({
+      x: e.clientX - dragStartRef.current.x,
+      y: e.clientY - dragStartRef.current.y,
+    });
+  };
+
+  const handlePointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (!dragStartRef.current) return;
+    const dx = e.clientX - dragStartRef.current.x;
+    const dy = e.clientY - dragStartRef.current.y;
+    dragStartRef.current = null;
+    setDrag({ x: 0, y: 0 });
+
+    // 좌·우 throw 가 임계 넘으면 수납 (위/아래 스냅보다 우선)
+    if (Math.abs(dx) > COLLAPSE_THRESHOLD_PX) {
+      onCollapse(dx > 0 ? 'right' : 'left');
+    } else if (Math.abs(dy) > SNAP_THRESHOLD_PX) {
+      if (dy > 0 && position === 'top') onMoveTo('bottom');
+      else if (dy < 0 && position === 'bottom') onMoveTo('top');
+    }
+
+    try {
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      }
+    } catch {
+      // ignore
+    }
+  };
+
   return (
     <div
       role='dialog'
       aria-modal='false'
       aria-label='시간 슬롯 상세'
-      style={{ maxWidth: CARD_MAX_W_PX }}
-      className='fixed inset-x-3 bottom-28 z-60 mx-auto rounded-2xl border border-gray-100 bg-white p-4 shadow-[0_8px_24px_rgba(0,0,0,0.08)]'
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      style={{
+        transform: `translate(${drag.x}px, ${drag.y}px)`,
+        transition:
+          drag.x === 0 && drag.y === 0
+            ? 'transform 200ms ease-out, top 200ms ease-out, bottom 200ms ease-out'
+            : 'none',
+        maxWidth: CARD_MAX_W_PX,
+      }}
+      className={`fixed inset-x-3 z-60 mx-auto cursor-grab touch-none rounded-2xl border border-gray-100 bg-white p-4 shadow-[0_8px_24px_rgba(0,0,0,0.08)] active:cursor-grabbing ${
+        position === 'top' ? 'top-16' : 'bottom-28'
+      }`}
     >
       <div className='flex items-center gap-2'>
         {rank !== null && (
@@ -82,6 +196,7 @@ export default function CellInfoCard({
           type='button'
           aria-label='닫기'
           onClick={onClose}
+          onPointerDown={(e) => e.stopPropagation()}
           className='text-text-tertiary hover:text-text-primary'
         >
           <svg width='20' height='20' viewBox='0 0 20 20' fill='none'>

--- a/src/features/meet-result-table/ui/CellInfoCard.tsx
+++ b/src/features/meet-result-table/ui/CellInfoCard.tsx
@@ -6,8 +6,8 @@ import {
   useState,
 } from 'react';
 
+import { type TimeRangeWithSlotCount } from '@/entities/meet/dto/meet.dto';
 import { type VoteTimeSlotStat } from '@/entities/voteTimeSlotStat/dto/voteTimeSlotStat.dto';
-import { SLOTS_PER_HOUR, START_HOUR } from '@/shared/config/timeSlot';
 import { parseDate } from '@/shared/lib/date';
 import Chip from '@/shared/ui/chip/Chip';
 import Icon from '@/shared/ui/icon/Icon';
@@ -36,9 +36,18 @@ function formatDate(dateStr: string): string {
   return `${month}월 ${day}일 ${weekday}요일`;
 }
 
-function formatSlotRange(slotIdx: number): string {
-  const startMin = START_HOUR * 60 + slotIdx * (60 / SLOTS_PER_HOUR);
-  const endMin = startMin + 60 / SLOTS_PER_HOUR;
+function timeToMinutes(t: string): number {
+  const [hh, mm] = t.split(':').map(Number);
+  return hh * 60 + mm;
+}
+
+/**
+ * 모임 timeRange.startTime 을 기준으로 slotIdx 의 30분 슬롯 시각 범위(`HH:mm - HH:mm`) 계산.
+ */
+function formatSlotRange(slotIdx: number, timeRangeStart: string): string {
+  const baseMin = timeToMinutes(timeRangeStart);
+  const startMin = baseMin + slotIdx * 30;
+  const endMin = startMin + 30;
   const fmt = (m: number) => {
     const h = Math.floor(m / 60);
     const mm = m % 60;
@@ -49,6 +58,7 @@ function formatSlotRange(slotIdx: number): string {
 
 interface CellInfoCardProps {
   slotStat: VoteTimeSlotStat;
+  timeRange: TimeRangeWithSlotCount;
   selected: SelectedCell;
   isExpanded: boolean;
   position: CardPosition;
@@ -61,6 +71,7 @@ interface CellInfoCardProps {
 
 export default function CellInfoCard({
   slotStat,
+  timeRange,
   selected,
   isExpanded,
   position,
@@ -190,7 +201,8 @@ export default function CellInfoCard({
           </span>
         )}
         <span className='text-text-primary flex-1 text-[15px] font-bold'>
-          {formatDate(selected.date)} {formatSlotRange(selected.slotIdx)}
+          {formatDate(selected.date)}{' '}
+          {formatSlotRange(selected.slotIdx, timeRange.startTime)}
         </span>
         <button
           type='button'

--- a/src/features/meet-result-table/ui/HeatmapCell.tsx
+++ b/src/features/meet-result-table/ui/HeatmapCell.tsx
@@ -1,5 +1,3 @@
-import { END_HOUR, SLOTS_PER_HOUR, START_HOUR } from '@/shared/config/timeSlot';
-
 import {
   BASE_TONE_CLASS,
   OPACITY_CLASS_MAP,
@@ -16,14 +14,6 @@ interface HeatmapCellProps {
   isSelected: boolean;
 }
 
-function formatSlotTime(slotIdx: number): string {
-  const totalMinutes = START_HOUR * 60 + slotIdx * (60 / SLOTS_PER_HOUR);
-  const hour = Math.floor(totalMinutes / 60);
-  const minute = totalMinutes % 60;
-  if (hour >= END_HOUR) return '';
-  return `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
-}
-
 export default function HeatmapCell({
   date,
   slotIdx,
@@ -35,13 +25,12 @@ export default function HeatmapCell({
 }: HeatmapCellProps) {
   const colorClass =
     intensity !== null ? OPACITY_CLASS_MAP[intensity] : BASE_TONE_CLASS;
-  const time = formatSlotTime(slotIdx);
 
   return (
     <button
       type='button'
       role='gridcell'
-      aria-label={`${date} ${time}: 가능한 사람 ${count}명`}
+      aria-label={`${date} 슬롯 ${slotIdx}: 가능한 사람 ${count}명`}
       aria-selected={isSelected}
       data-date={date}
       data-slot-idx={slotIdx}

--- a/src/features/meet-result-table/ui/HeatmapCell.tsx
+++ b/src/features/meet-result-table/ui/HeatmapCell.tsx
@@ -47,9 +47,7 @@ export default function HeatmapCell({
       data-slot-idx={slotIdx}
       onClick={() => onSelect(date, slotIdx)}
       style={{ height }}
-      className={`box-border w-full cursor-pointer ${colorClass} ${
-        isSelected ? 'ring-2 ring-[#3C7EFA] ring-offset-1' : ''
-      }`}
+      className={`box-border w-full cursor-pointer ${colorClass}`}
     />
   );
 }

--- a/src/features/meet-result-table/ui/HeatmapGrid.tsx
+++ b/src/features/meet-result-table/ui/HeatmapGrid.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { isSameWeek } from 'date-fns';
 import { useMemo } from 'react';
 
 import {
@@ -19,6 +20,9 @@ const TIME_COL_W = 40;
 const DAY_HEADER_H = 56;
 const COL_GAP = 4;
 const ROW_GAP = 4;
+// 인접 컬럼이 서로 다른 ISO 주(월~일) 에 속할 때 일반 갭 위에 추가로 더하는 마진.
+// 시안 (Figma 3627:6155) 기준 토 → 월 같이 주가 바뀌는 경계에 시각 단서를 준다.
+const WEEK_GAP_EXTRA = 12;
 const GRID_PADDING_X = 20; // must match px-5 on grid wrapper
 const VISIBLE_COLS = 4.5; // 4 full + 0.5 cutoff cue (FR-021)
 const VISIBLE_GAPS = 4; // gaps between the visible columns
@@ -89,13 +93,26 @@ export default function HeatmapGrid({
       </div>
 
       <div className='flex' style={{ gap: COL_GAP }}>
-        {slotStat.dates.map((date) => {
+        {slotStat.dates.map((date, dateIndex) => {
           const { weekday, md } = formatDateHeader(date);
           const dow = parseDate(date).getDay();
           const isWeekend = dow === 0 || dow === 6;
+          const prevDate = dateIndex > 0 ? slotStat.dates[dateIndex - 1] : null;
+          const isWeekChange =
+            prevDate !== null &&
+            !isSameWeek(parseDate(prevDate), parseDate(date), {
+              weekStartsOn: 1,
+            });
 
           return (
-            <div key={date} className='shrink-0' style={{ width: COL_W }}>
+            <div
+              key={date}
+              className='shrink-0'
+              style={{
+                width: COL_W,
+                marginLeft: isWeekChange ? WEEK_GAP_EXTRA : undefined,
+              }}
+            >
               <div
                 role='columnheader'
                 style={{ height: DAY_HEADER_H }}

--- a/src/features/meet-result-table/ui/HeatmapGrid.tsx
+++ b/src/features/meet-result-table/ui/HeatmapGrid.tsx
@@ -67,7 +67,7 @@ export default function HeatmapGrid({
       role='grid'
       aria-rowcount={TOTAL_SLOTS + 1}
       aria-colcount={slotStat.dates.length + 1}
-      className='flex w-full overflow-auto px-5 pb-5'
+      className='flex w-full overflow-auto pb-5'
     >
       <div
         className='sticky left-0 z-20 shrink-0 bg-white'

--- a/src/features/meet-result-table/ui/HeatmapGrid.tsx
+++ b/src/features/meet-result-table/ui/HeatmapGrid.tsx
@@ -3,11 +3,11 @@
 import { isSameWeek } from 'date-fns';
 import { useMemo } from 'react';
 
+import { type TimeRangeWithSlotCount } from '@/entities/meet/dto/meet.dto';
 import {
   type TimeSlotCell,
   type VoteTimeSlotStat,
 } from '@/entities/voteTimeSlotStat/dto/voteTimeSlotStat.dto';
-import { END_HOUR, START_HOUR, TOTAL_SLOTS } from '@/shared/config/timeSlot';
 import { parseDate } from '@/shared/lib/date';
 
 import { computeHeatmapIntensity } from '../lib/computeHeatmapIntensity';
@@ -37,14 +37,21 @@ function formatDateHeader(dateStr: string): { weekday: string; md: string } {
   return { weekday: WEEK_KO[d.getDay()], md: `${month}.${day}` };
 }
 
+function timeToMinutes(t: string): number {
+  const [hh, mm] = t.split(':').map(Number);
+  return hh * 60 + mm;
+}
+
 interface HeatmapGridProps {
   slotStat: VoteTimeSlotStat;
+  timeRange: TimeRangeWithSlotCount;
   selected: { date: string; slotIdx: number } | null;
   onSelect: (date: string, slotIdx: number) => void;
 }
 
 export default function HeatmapGrid({
   slotStat,
+  timeRange,
   selected,
   onSelect,
 }: HeatmapGridProps) {
@@ -61,15 +68,45 @@ export default function HeatmapGrid({
     return map;
   }, [slotStat.cells]);
 
-  const hours = Array.from(
-    { length: END_HOUR - START_HOUR },
-    (_, i) => START_HOUR + i,
-  );
+  // timeRange 의 startTime ~ endTime 만 표시.
+  // 1시간 = 2 슬롯 그룹. 시작이 30분 오프셋이면 첫 그룹은 botSlot 만.
+  const startMin = timeToMinutes(timeRange.startTime);
+  const startHour = Math.floor(startMin / 60);
+  const startHasHalfOffset = startMin % 60 === 30;
+  const endMin = timeToMinutes(timeRange.endTime);
+  const endHour = Math.ceil(endMin / 60);
+
+  const groups: Array<{
+    hour: number;
+    topSlotIdx: number | null;
+    botSlotIdx: number | null;
+  }> = [];
+  {
+    let cursor = 0;
+    if (startHasHalfOffset) {
+      groups.push({ hour: startHour, topSlotIdx: null, botSlotIdx: cursor });
+      cursor += 1;
+    }
+    for (
+      let h = startHasHalfOffset ? startHour + 1 : startHour;
+      h < endHour;
+      h += 1
+    ) {
+      const top = cursor;
+      const bot = cursor + 1;
+      groups.push({
+        hour: h,
+        topSlotIdx: top,
+        botSlotIdx: bot < timeRange.slotCount ? bot : null,
+      });
+      cursor += 2;
+    }
+  }
 
   return (
     <div
       role='grid'
-      aria-rowcount={TOTAL_SLOTS + 1}
+      aria-rowcount={timeRange.slotCount + 1}
       aria-colcount={slotStat.dates.length + 1}
       className='flex w-full overflow-auto pb-5'
     >
@@ -79,14 +116,14 @@ export default function HeatmapGrid({
       >
         <div style={{ height: DAY_HEADER_H }} />
         <div className='flex flex-col' style={{ gap: ROW_GAP }}>
-          {hours.map((hour) => (
+          {groups.map((group) => (
             <div
-              key={hour}
+              key={group.hour}
               role='rowheader'
               style={{ height: HOUR_H }}
               className='text-text-tertiary flex items-start justify-end pr-2 text-[14px] leading-5 font-medium'
             >
-              {hour}
+              {group.hour}
             </div>
           ))}
         </div>
@@ -131,35 +168,43 @@ export default function HeatmapGrid({
               </div>
 
               <div className='flex flex-col' style={{ gap: ROW_GAP }}>
-                {hours.map((_, hourIdx) => {
-                  const topSlotIdx = hourIdx * 2;
-                  const botSlotIdx = hourIdx * 2 + 1;
-                  const topKey = cellKey(date, topSlotIdx);
-                  const botKey = cellKey(date, botSlotIdx);
-                  const topCell = cellByKey.get(topKey);
-                  const botCell = cellByKey.get(botKey);
-                  const topIntensity = intensityMap.get(topKey) ?? null;
-                  const botIntensity = intensityMap.get(botKey) ?? null;
+                {groups.map((group) => {
+                  const topSlotIdx = group.topSlotIdx;
+                  const botSlotIdx = group.botSlotIdx;
+                  const topKey =
+                    topSlotIdx !== null ? cellKey(date, topSlotIdx) : null;
+                  const botKey =
+                    botSlotIdx !== null ? cellKey(date, botSlotIdx) : null;
+                  const topCell = topKey ? cellByKey.get(topKey) : undefined;
+                  const botCell = botKey ? cellByKey.get(botKey) : undefined;
+                  const topIntensity =
+                    topKey !== null ? (intensityMap.get(topKey) ?? null) : null;
+                  const botIntensity =
+                    botKey !== null ? (intensityMap.get(botKey) ?? null) : null;
 
                   return (
                     <div
-                      key={hourIdx}
+                      key={`${date}-${group.hour}`}
                       role='row'
                       className='overflow-hidden rounded-[10px]'
                       style={{ height: HOUR_H }}
                     >
-                      <HeatmapCell
-                        date={date}
-                        slotIdx={topSlotIdx}
-                        intensity={topIntensity}
-                        count={topCell?.count ?? 0}
-                        height={SLOT_H}
-                        onSelect={onSelect}
-                        isSelected={
-                          selected?.date === date &&
-                          selected?.slotIdx === topSlotIdx
-                        }
-                      />
+                      {topSlotIdx !== null ? (
+                        <HeatmapCell
+                          date={date}
+                          slotIdx={topSlotIdx}
+                          intensity={topIntensity}
+                          count={topCell?.count ?? 0}
+                          height={SLOT_H}
+                          onSelect={onSelect}
+                          isSelected={
+                            selected?.date === date &&
+                            selected?.slotIdx === topSlotIdx
+                          }
+                        />
+                      ) : (
+                        <div style={{ height: SLOT_H }} />
+                      )}
                       <div
                         className='border-t border-dashed border-white/40'
                         style={{
@@ -167,18 +212,22 @@ export default function HeatmapGrid({
                           opacity: botIntensity !== null ? 1 : 0,
                         }}
                       />
-                      <HeatmapCell
-                        date={date}
-                        slotIdx={botSlotIdx}
-                        intensity={botIntensity}
-                        count={botCell?.count ?? 0}
-                        height={SLOT_H}
-                        onSelect={onSelect}
-                        isSelected={
-                          selected?.date === date &&
-                          selected?.slotIdx === botSlotIdx
-                        }
-                      />
+                      {botSlotIdx !== null ? (
+                        <HeatmapCell
+                          date={date}
+                          slotIdx={botSlotIdx}
+                          intensity={botIntensity}
+                          count={botCell?.count ?? 0}
+                          height={SLOT_H}
+                          onSelect={onSelect}
+                          isSelected={
+                            selected?.date === date &&
+                            selected?.slotIdx === botSlotIdx
+                          }
+                        />
+                      ) : (
+                        <div style={{ height: SLOT_H }} />
+                      )}
                     </div>
                   );
                 })}

--- a/src/features/meet-result-table/ui/MeetResultTablePage.tsx
+++ b/src/features/meet-result-table/ui/MeetResultTablePage.tsx
@@ -43,6 +43,7 @@ export default function MeetResultTablePage({
     return (
       <ResultTableView
         slotStat={slotStat}
+        timeRange={snapshot.timeRange}
         voteCount={voteCount}
         mode={mode}
         onToggle={toggle}

--- a/src/features/meet-result-table/ui/MeetResultTablePage.tsx
+++ b/src/features/meet-result-table/ui/MeetResultTablePage.tsx
@@ -24,16 +24,7 @@ export default function MeetResultTablePage({
   snapshot,
 }: MeetResultTablePageProps) {
   const { mode, toggle } = useViewMode('table');
-  const {
-    selected,
-    isExpanded,
-    position,
-    select,
-    close,
-    collapse,
-    expand,
-    moveTo,
-  } = useSelectedCell();
+  const { selected, select, close } = useSelectedCell();
   const { openIds, toggle: cardToggle } = useVoteRankCardToggle();
   const result = useMemo(() => toRankedSlots(snapshot), [snapshot]);
   const voteCount = result.totalVoters;
@@ -46,13 +37,8 @@ export default function MeetResultTablePage({
         mode={mode}
         onToggle={toggle}
         selected={selected}
-        isExpanded={isExpanded}
-        position={position}
         onSelect={select}
         onClose={close}
-        onCollapse={collapse}
-        onExpand={expand}
-        onMoveTo={moveTo}
       />
     );
   }

--- a/src/features/meet-result-table/ui/MeetResultTablePage.tsx
+++ b/src/features/meet-result-table/ui/MeetResultTablePage.tsx
@@ -24,7 +24,17 @@ export default function MeetResultTablePage({
   snapshot,
 }: MeetResultTablePageProps) {
   const { mode, toggle } = useViewMode('table');
-  const { selected, select, close } = useSelectedCell();
+  const {
+    selected,
+    isExpanded,
+    position,
+    collapsedSide,
+    select,
+    close,
+    collapse,
+    expand,
+    moveTo,
+  } = useSelectedCell();
   const { openIds, toggle: cardToggle } = useVoteRankCardToggle();
   const result = useMemo(() => toRankedSlots(snapshot), [snapshot]);
   const voteCount = result.totalVoters;
@@ -37,8 +47,14 @@ export default function MeetResultTablePage({
         mode={mode}
         onToggle={toggle}
         selected={selected}
+        isExpanded={isExpanded}
+        position={position}
+        collapsedSide={collapsedSide}
         onSelect={select}
         onClose={close}
+        onCollapse={collapse}
+        onExpand={expand}
+        onMoveTo={moveTo}
       />
     );
   }

--- a/src/features/meet-result-table/ui/ResultTableView.tsx
+++ b/src/features/meet-result-table/ui/ResultTableView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { type TimeRangeWithSlotCount } from '@/entities/meet/dto/meet.dto';
 import { type VoteTimeSlotStat } from '@/entities/voteTimeSlotStat/dto/voteTimeSlotStat.dto';
 
 import {
@@ -14,6 +15,7 @@ import ResultCountBar from './ResultCountBar';
 
 interface ResultTableViewProps {
   slotStat: VoteTimeSlotStat;
+  timeRange: TimeRangeWithSlotCount;
   voteCount: number;
   mode: ViewMode;
   onToggle: () => void;
@@ -30,6 +32,7 @@ interface ResultTableViewProps {
 
 export default function ResultTableView({
   slotStat,
+  timeRange,
   voteCount,
   mode,
   onToggle,
@@ -49,11 +52,13 @@ export default function ResultTableView({
       <div className='@container relative'>
         <HeatmapGrid
           slotStat={slotStat}
+          timeRange={timeRange}
           selected={selected}
           onSelect={onSelect}
         />
         <CellInfoCard
           slotStat={slotStat}
+          timeRange={timeRange}
           selected={selected}
           isExpanded={isExpanded}
           position={position}

--- a/src/features/meet-result-table/ui/ResultTableView.tsx
+++ b/src/features/meet-result-table/ui/ResultTableView.tsx
@@ -2,7 +2,11 @@
 
 import { type VoteTimeSlotStat } from '@/entities/voteTimeSlotStat/dto/voteTimeSlotStat.dto';
 
-import { type SelectedCell } from '../model/useSelectedCell';
+import {
+  type CardPosition,
+  type CollapsedSide,
+  type SelectedCell,
+} from '../model/useSelectedCell';
 import { type ViewMode } from '../model/useViewMode';
 import CellInfoCard from './CellInfoCard';
 import HeatmapGrid from './HeatmapGrid';
@@ -14,8 +18,14 @@ interface ResultTableViewProps {
   mode: ViewMode;
   onToggle: () => void;
   selected: SelectedCell;
+  isExpanded: boolean;
+  position: CardPosition;
+  collapsedSide: CollapsedSide;
   onSelect: (date: string, slotIdx: number) => void;
   onClose: () => void;
+  onCollapse: (side: CollapsedSide) => void;
+  onExpand: () => void;
+  onMoveTo: (position: CardPosition) => void;
 }
 
 export default function ResultTableView({
@@ -24,8 +34,14 @@ export default function ResultTableView({
   mode,
   onToggle,
   selected,
+  isExpanded,
+  position,
+  collapsedSide,
   onSelect,
   onClose,
+  onCollapse,
+  onExpand,
+  onMoveTo,
 }: ResultTableViewProps) {
   return (
     <div className='mx-auto w-full max-w-screen-sm'>
@@ -39,7 +55,13 @@ export default function ResultTableView({
         <CellInfoCard
           slotStat={slotStat}
           selected={selected}
+          isExpanded={isExpanded}
+          position={position}
+          collapsedSide={collapsedSide}
           onClose={onClose}
+          onCollapse={onCollapse}
+          onExpand={onExpand}
+          onMoveTo={onMoveTo}
         />
       </div>
     </div>

--- a/src/features/meet-result-table/ui/ResultTableView.tsx
+++ b/src/features/meet-result-table/ui/ResultTableView.tsx
@@ -2,7 +2,7 @@
 
 import { type VoteTimeSlotStat } from '@/entities/voteTimeSlotStat/dto/voteTimeSlotStat.dto';
 
-import { type CardPosition, type SelectedCell } from '../model/useSelectedCell';
+import { type SelectedCell } from '../model/useSelectedCell';
 import { type ViewMode } from '../model/useViewMode';
 import CellInfoCard from './CellInfoCard';
 import HeatmapGrid from './HeatmapGrid';
@@ -14,13 +14,8 @@ interface ResultTableViewProps {
   mode: ViewMode;
   onToggle: () => void;
   selected: SelectedCell;
-  isExpanded: boolean;
-  position: CardPosition;
   onSelect: (date: string, slotIdx: number) => void;
   onClose: () => void;
-  onCollapse: () => void;
-  onExpand: () => void;
-  onMoveTo: (next: CardPosition) => void;
 }
 
 export default function ResultTableView({
@@ -29,13 +24,8 @@ export default function ResultTableView({
   mode,
   onToggle,
   selected,
-  isExpanded,
-  position,
   onSelect,
   onClose,
-  onCollapse,
-  onExpand,
-  onMoveTo,
 }: ResultTableViewProps) {
   return (
     <div className='mx-auto w-full max-w-screen-sm'>
@@ -49,12 +39,7 @@ export default function ResultTableView({
         <CellInfoCard
           slotStat={slotStat}
           selected={selected}
-          isExpanded={isExpanded}
-          position={position}
           onClose={onClose}
-          onCollapse={onCollapse}
-          onExpand={onExpand}
-          onMoveTo={onMoveTo}
         />
       </div>
     </div>

--- a/src/features/participant-register-time-slot/lib/timeSlotMatrix.test.ts
+++ b/src/features/participant-register-time-slot/lib/timeSlotMatrix.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  matrixToSelection,
+  rectKeys,
+  selectionToMatrix,
+  slotKey,
+} from '@/features/participant-register-time-slot/lib/timeSlotMatrix';
+
+describe('slotKey', () => {
+  it('encodes (dateIndex, slotIndex) as "d:s"', () => {
+    expect(slotKey(2, 5)).toBe('2:5');
+  });
+});
+
+describe('selectionToMatrix', () => {
+  it('빈 selection → 모든 false', () => {
+    const matrix = selectionToMatrix(new Set(), 2, 3);
+
+    expect(matrix).toEqual([
+      [false, false, false],
+      [false, false, false],
+    ]);
+  });
+
+  it('일부 선택된 키 → 해당 위치만 true', () => {
+    const matrix = selectionToMatrix(new Set(['0:1', '1:2']), 2, 3);
+
+    expect(matrix).toEqual([
+      [false, true, false],
+      [false, false, true],
+    ]);
+  });
+});
+
+describe('matrixToSelection', () => {
+  it('matrix 의 true 셀만 키로 추출', () => {
+    const set = matrixToSelection([
+      [false, true, false],
+      [true, false, false],
+    ]);
+
+    expect(set.has('0:1')).toBe(true);
+    expect(set.has('1:0')).toBe(true);
+    expect(set.size).toBe(2);
+  });
+});
+
+describe('rectKeys', () => {
+  it('단일 셀', () => {
+    expect(rectKeys(1, 2, 1, 2)).toEqual(['1:2']);
+  });
+
+  it('수직 드래그 (같은 날짜, 다른 시간)', () => {
+    expect(rectKeys(0, 1, 0, 3)).toEqual(['0:1', '0:2', '0:3']);
+  });
+
+  it('역방향 드래그도 정렬된 사각형 반환', () => {
+    expect(rectKeys(0, 3, 0, 1)).toEqual(['0:1', '0:2', '0:3']);
+  });
+
+  it('대각선 드래그 (사각형 영역 전체)', () => {
+    expect(rectKeys(0, 0, 1, 1)).toEqual(['0:0', '0:1', '1:0', '1:1']);
+  });
+});

--- a/src/features/participant-register-time-slot/lib/timeSlotMatrix.ts
+++ b/src/features/participant-register-time-slot/lib/timeSlotMatrix.ts
@@ -1,0 +1,58 @@
+/**
+ * (dateIndex, slotIndex) 키 인코딩.
+ * Set<string> 으로 선택 상태를 보관하기 위한 헬퍼.
+ */
+export function slotKey(dateIndex: number, slotIndex: number): string {
+  return `${dateIndex}:${slotIndex}`;
+}
+
+/**
+ * Set<slotKey> → boolean[][]
+ * 차원: dates.length × slotCount
+ */
+export function selectionToMatrix(
+  selected: Set<string>,
+  datesLength: number,
+  slotCount: number,
+): boolean[][] {
+  return Array.from({ length: datesLength }, (_, d) =>
+    Array.from({ length: slotCount }, (_, s) => selected.has(slotKey(d, s))),
+  );
+}
+
+/**
+ * boolean[][] → Set<slotKey>
+ */
+export function matrixToSelection(matrix: boolean[][]): Set<string> {
+  const set = new Set<string>();
+  for (let d = 0; d < matrix.length; d += 1) {
+    const row = matrix[d];
+    for (let s = 0; s < row.length; s += 1) {
+      if (row[s]) set.add(slotKey(d, s));
+    }
+  }
+  return set;
+}
+
+/**
+ * 시작 셀 (dateA, slotA) ~ 끝 셀 (dateB, slotB) 사이 직사각형 영역의 키 집합.
+ * 같은 dateIndex 컬럼 내에서만 드래그하지만, 안전하게 양방향 처리.
+ */
+export function rectKeys(
+  startDate: number,
+  startSlot: number,
+  endDate: number,
+  endSlot: number,
+): string[] {
+  const dMin = Math.min(startDate, endDate);
+  const dMax = Math.max(startDate, endDate);
+  const sMin = Math.min(startSlot, endSlot);
+  const sMax = Math.max(startSlot, endSlot);
+  const keys: string[] = [];
+  for (let d = dMin; d <= dMax; d += 1) {
+    for (let s = sMin; s <= sMax; s += 1) {
+      keys.push(slotKey(d, s));
+    }
+  }
+  return keys;
+}

--- a/src/features/participant-register-time-slot/model/useParticipantEditTimeSlot.ts
+++ b/src/features/participant-register-time-slot/model/useParticipantEditTimeSlot.ts
@@ -1,0 +1,171 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import { getMeetingById } from '@/entities/meet/api/getMeetingById';
+import { updateVote } from '@/entities/meet/api/updateVote';
+import {
+  type MeetResponse,
+  type TimeRangeWithSlotCount,
+} from '@/entities/meet/dto/meet.dto';
+import {
+  matrixToSelection,
+  selectionToMatrix,
+} from '@/features/participant-register-time-slot/lib/timeSlotMatrix';
+import { useTimeSlotSelection } from '@/features/participant-register-time-slot/model/useTimeSlotSelection';
+import { useDisclosure } from '@/shared/hooks/useDisclosure';
+
+interface UseParticipantEditTimeSlotResult {
+  isLoading: boolean;
+  meetingTitle: string;
+  dates: string[];
+  timeRange: TimeRangeWithSlotCount | null;
+  isAllImpossible: boolean;
+  isSubmitting: boolean;
+  isCtaActive: boolean;
+  isSelected: (dateIndex: number, slotIndex: number) => boolean;
+  beginDrag: (dateIndex: number, slotIndex: number) => void;
+  updateDrag: (dateIndex: number, slotIndex: number) => void;
+  endDrag: () => void;
+  handleAllImpossibleChange: (checked: boolean) => void;
+  handleBack: () => void;
+  handleSubmit: () => Promise<void>;
+  isSuccessModalOpen: boolean;
+  handleSuccessModalClose: () => void;
+}
+
+export function useParticipantEditTimeSlot(
+  meetingId: string,
+): UseParticipantEditTimeSlotResult {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const nameFromQuery = searchParams.get('name');
+  const STORE_KEY = `last_participant_name_${meetingId}`;
+
+  const [participantName, setParticipantName] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [meetingData, setMeetingData] = useState<MeetResponse | null>(null);
+  const [isAllImpossible, setIsAllImpossible] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const {
+    selected,
+    isSelected,
+    beginDrag,
+    updateDrag,
+    endDrag,
+    reset,
+    replaceSelection,
+  } = useTimeSlotSelection();
+
+  const successModal = useDisclosure();
+
+  useEffect(() => {
+    let currentName = nameFromQuery;
+    if (!currentName && typeof window !== 'undefined') {
+      currentName = localStorage.getItem(STORE_KEY);
+    }
+    if (!currentName) {
+      router.replace(`/meet/${meetingId}/edit`);
+      return;
+    }
+    setParticipantName(currentName);
+
+    const fetchData = async () => {
+      try {
+        const data = await getMeetingById(meetingId);
+        setMeetingData(data);
+
+        const participant = data.participants.find(
+          (p) => p.name === currentName,
+        );
+        if (participant?.voteTimeSlots?.length) {
+          replaceSelection(matrixToSelection(participant.voteTimeSlots));
+        }
+      } catch (error) {
+        console.error('Failed to fetch meeting data:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, [meetingId, nameFromQuery, router, STORE_KEY, replaceSelection]);
+
+  const handleAllImpossibleChange = (checked: boolean) => {
+    setIsAllImpossible(checked);
+    if (checked) reset();
+  };
+
+  const handleBack = () => {
+    const params = new URLSearchParams();
+    if (participantName) params.set('name', participantName);
+    router.replace(`/meet/${meetingId}/edit?${params.toString()}`);
+  };
+
+  const handleSuccessModalClose = () => {
+    successModal.close();
+    router.replace(`/meet/${meetingId}`);
+  };
+
+  // 서버 응답 dates 순서를 그대로 사용. (register hook 과 동일 정책)
+  const dates = meetingData?.dates ?? [];
+  const timeRange = meetingData?.timeRange ?? null;
+
+  const handleSubmit = async () => {
+    if (isSubmitting || !meetingData || !timeRange) return;
+
+    try {
+      setIsSubmitting(true);
+
+      const voteTimeSlots = isAllImpossible
+        ? dates.map(() => Array(timeRange.slotCount).fill(false))
+        : selectionToMatrix(selected, dates.length, timeRange.slotCount);
+
+      const voteDates = isAllImpossible
+        ? []
+        : dates.filter((_, dateIndex) =>
+            voteTimeSlots[dateIndex].some((v) => v),
+          );
+
+      await updateVote({
+        meetingId,
+        name: participantName,
+        voteDates,
+        voteTimeSlots,
+      });
+
+      successModal.open();
+    } catch (error) {
+      console.error('Failed to update vote:', error);
+      alert('투표 수정에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const isCtaActive = isAllImpossible || selected.size > 0;
+
+  return {
+    isLoading,
+    meetingTitle: meetingData?.title ?? '',
+    dates,
+    timeRange,
+    isAllImpossible,
+    isSubmitting,
+    isCtaActive,
+    isSelected,
+    beginDrag: (d, s) => {
+      if (isAllImpossible) setIsAllImpossible(false);
+      beginDrag(d, s);
+    },
+    updateDrag,
+    endDrag,
+    handleAllImpossibleChange,
+    handleBack,
+    handleSubmit,
+    isSuccessModalOpen: successModal.isOpen,
+    handleSuccessModalClose,
+  };
+}

--- a/src/features/participant-register-time-slot/model/useParticipantRegisterTimeSlot.ts
+++ b/src/features/participant-register-time-slot/model/useParticipantRegisterTimeSlot.ts
@@ -1,0 +1,158 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import { getMeetingById } from '@/entities/meet/api/getMeetingById';
+import { voteMeeting } from '@/entities/meet/api/voteMeeting';
+import {
+  type MeetResponse,
+  type TimeRangeWithSlotCount,
+} from '@/entities/meet/dto/meet.dto';
+import { selectionToMatrix } from '@/features/participant-register-time-slot/lib/timeSlotMatrix';
+import { useTimeSlotSelection } from '@/features/participant-register-time-slot/model/useTimeSlotSelection';
+import { useDisclosure } from '@/shared/hooks/useDisclosure';
+
+interface UseParticipantRegisterTimeSlotResult {
+  isLoading: boolean;
+  meetingTitle: string;
+  dates: string[];
+  timeRange: TimeRangeWithSlotCount | null;
+  isAllImpossible: boolean;
+  isSubmitting: boolean;
+  isCtaActive: boolean;
+  isSelected: (dateIndex: number, slotIndex: number) => boolean;
+  beginDrag: (dateIndex: number, slotIndex: number) => void;
+  updateDrag: (dateIndex: number, slotIndex: number) => void;
+  endDrag: () => void;
+  handleAllImpossibleChange: (checked: boolean) => void;
+  handleBack: () => void;
+  handleSubmit: () => Promise<void>;
+  isSuccessModalOpen: boolean;
+  handleSuccessModalClose: () => void;
+}
+
+export function useParticipantRegisterTimeSlot(
+  meetingId: string,
+): UseParticipantRegisterTimeSlotResult {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const nameFromQuery = searchParams.get('name');
+  const STORE_KEY = `last_participant_name_${meetingId}`;
+
+  const [participantName, setParticipantName] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [meetingData, setMeetingData] = useState<MeetResponse | null>(null);
+  const [isAllImpossible, setIsAllImpossible] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { selected, isSelected, beginDrag, updateDrag, endDrag, reset } =
+    useTimeSlotSelection();
+
+  const successModal = useDisclosure();
+
+  useEffect(() => {
+    let currentName = nameFromQuery;
+    if (!currentName && typeof window !== 'undefined') {
+      currentName = localStorage.getItem(STORE_KEY);
+    }
+    if (!currentName) {
+      router.replace(`/meet/${meetingId}/register`);
+      return;
+    }
+    setParticipantName(currentName);
+
+    const fetchData = async () => {
+      try {
+        const data = await getMeetingById(meetingId);
+        setMeetingData(data);
+      } catch (error) {
+        console.error('Failed to fetch meeting data:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, [meetingId, nameFromQuery, router, STORE_KEY]);
+
+  const handleAllImpossibleChange = (checked: boolean) => {
+    setIsAllImpossible(checked);
+    if (checked) reset();
+  };
+
+  const handleBack = () => {
+    const params = new URLSearchParams();
+    if (participantName) params.set('name', participantName);
+    router.replace(`/meet/${meetingId}/register?${params.toString()}`);
+  };
+
+  const handleSuccessModalClose = () => {
+    successModal.close();
+    router.replace(`/meet/${meetingId}`);
+  };
+
+  // 서버 응답의 dates 순서를 그대로 사용 (정렬된 채로 응답된다는 컨벤션).
+  // 정렬을 클라이언트에서 추가로 적용하면 voteTimeSlots row 와 dates 인덱스 매핑이
+  // 서버 기대값과 어긋나 잘못된 셀에 저장될 수 있음.
+  const dates = meetingData?.dates ?? [];
+  const timeRange = meetingData?.timeRange ?? null;
+
+  const handleSubmit = async () => {
+    if (isSubmitting || !meetingData) return;
+    if (!timeRange) return;
+
+    try {
+      setIsSubmitting(true);
+
+      const voteTimeSlots = isAllImpossible
+        ? dates.map(() => Array(timeRange.slotCount).fill(false))
+        : selectionToMatrix(selected, dates.length, timeRange.slotCount);
+
+      // 시간 모임에서도 voteDates 는 함께 보낸다 (선택된 시각이 있는 날짜들).
+      const voteDates = isAllImpossible
+        ? []
+        : dates.filter((_, dateIndex) =>
+            voteTimeSlots[dateIndex].some((v) => v),
+          );
+
+      await voteMeeting({
+        meetingId,
+        name: participantName,
+        voteDates,
+        voteTimeSlots,
+      });
+
+      successModal.open();
+    } catch (error) {
+      console.error('Failed to create vote:', error);
+      alert('투표 제출에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const isCtaActive = isAllImpossible || selected.size > 0;
+
+  return {
+    isLoading,
+    meetingTitle: meetingData?.title ?? '',
+    dates,
+    timeRange,
+    isAllImpossible,
+    isSubmitting,
+    isCtaActive,
+    isSelected,
+    beginDrag: (d, s) => {
+      if (isAllImpossible) setIsAllImpossible(false);
+      beginDrag(d, s);
+    },
+    updateDrag,
+    endDrag,
+    handleAllImpossibleChange,
+    handleBack,
+    handleSubmit,
+    isSuccessModalOpen: successModal.isOpen,
+    handleSuccessModalClose,
+  };
+}

--- a/src/features/participant-register-time-slot/model/useTimeSlotSelection.ts
+++ b/src/features/participant-register-time-slot/model/useTimeSlotSelection.ts
@@ -1,0 +1,106 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+import {
+  rectKeys,
+  slotKey,
+} from '@/features/participant-register-time-slot/lib/timeSlotMatrix';
+
+interface UseTimeSlotSelectionOptions {
+  initial?: Set<string>;
+}
+
+/**
+ * 30분 슬롯 그리드의 드래그 다중 선택 상태 훅.
+ * - `beginDrag`: pointer down. 시작 셀이 unselected → additive(추가) 모드, selected → remove(해제) 모드.
+ * - `updateDrag`: pointer enter. 시작점 ~ 현재점 사각형 영역에 모드 적용.
+ * - `endDrag`: pointer up/cancel/leave. 드래그 종료.
+ * - `reset` / `replaceSelection`: 외부에서 selection 일괄 변경 (빈 set / 기존 투표 채움 등).
+ *
+ * 드래그 진행 중 중간 위치(`draggingTo`) 는 외부에 노출하지 않는다 (매 pointermove
+ * 시 setState 가 발생하면 그리드 전체가 리렌더되어 성능 저하). 시각 피드백은
+ * `selected` set 자체로 충분하다.
+ */
+export function useTimeSlotSelection(
+  options: UseTimeSlotSelectionOptions = {},
+) {
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(options.initial),
+  );
+  const dragOriginRef = useRef<{
+    dateIndex: number;
+    slotIndex: number;
+    additive: boolean;
+    baseline: Set<string>;
+  } | null>(null);
+
+  const beginDrag = useCallback(
+    (dateIndex: number, slotIndex: number) => {
+      const key = slotKey(dateIndex, slotIndex);
+      const additive = !selected.has(key);
+      dragOriginRef.current = {
+        dateIndex,
+        slotIndex,
+        additive,
+        baseline: new Set(selected),
+      };
+      setSelected((prev) => {
+        const next = new Set(prev);
+        if (additive) next.add(key);
+        else next.delete(key);
+        return next;
+      });
+    },
+    [selected],
+  );
+
+  const updateDrag = useCallback((dateIndex: number, slotIndex: number) => {
+    const origin = dragOriginRef.current;
+    if (!origin) return;
+    const region = rectKeys(
+      origin.dateIndex,
+      origin.slotIndex,
+      dateIndex,
+      slotIndex,
+    );
+    setSelected(() => {
+      const next = new Set(origin.baseline);
+      if (origin.additive) {
+        for (const key of region) next.add(key);
+      } else {
+        for (const key of region) next.delete(key);
+      }
+      return next;
+    });
+  }, []);
+
+  const endDrag = useCallback(() => {
+    dragOriginRef.current = null;
+  }, []);
+
+  const reset = useCallback(() => {
+    setSelected(new Set());
+    dragOriginRef.current = null;
+  }, []);
+
+  const replaceSelection = useCallback((next: Set<string>) => {
+    setSelected(new Set(next));
+  }, []);
+
+  const isSelected = useCallback(
+    (dateIndex: number, slotIndex: number) =>
+      selected.has(slotKey(dateIndex, slotIndex)),
+    [selected],
+  );
+
+  return {
+    selected,
+    isSelected,
+    beginDrag,
+    updateDrag,
+    endDrag,
+    reset,
+    replaceSelection,
+  };
+}

--- a/src/features/participant-register-time-slot/ui/ParticipantEditTimeSlotPage.tsx
+++ b/src/features/participant-register-time-slot/ui/ParticipantEditTimeSlotPage.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useParticipantEditTimeSlot } from '@/features/participant-register-time-slot/model/useParticipantEditTimeSlot';
+import TimeSlotGrid from '@/features/participant-register-time-slot/ui/TimeSlotGrid';
+import { trackEvent } from '@/shared/lib/amplitude';
+import SuccessBottomSheet from '@/shared/ui/bottom-sheet/SuccessBottomSheet';
+import Button from '@/shared/ui/button/Button';
+import Checkbox from '@/shared/ui/checkbox/Checkbox';
+import { Header } from '@/shared/ui/header/Header';
+import TopBar from '@/shared/ui/top-bar/TopBar';
+
+interface ParticipantEditTimeSlotPageProps {
+  meetingId: string;
+}
+
+export default function ParticipantEditTimeSlotPage({
+  meetingId,
+}: ParticipantEditTimeSlotPageProps) {
+  const {
+    isLoading,
+    dates,
+    timeRange,
+    isAllImpossible,
+    isCtaActive,
+    isSelected,
+    beginDrag,
+    updateDrag,
+    endDrag,
+    handleAllImpossibleChange,
+    handleBack,
+    handleSubmit,
+    isSuccessModalOpen,
+    handleSuccessModalClose,
+  } = useParticipantEditTimeSlot(meetingId);
+
+  const handleSubmitWithTracking = () => {
+    trackEvent('voter_vote_edit_completed_cta_click');
+    handleSubmit();
+  };
+
+  const handleSuccessModalCloseWithTracking = () => {
+    trackEvent('voter_vote_completed_cta_click');
+    handleSuccessModalClose();
+  };
+
+  if (isLoading || !timeRange) {
+    return (
+      <div className='min-h-screen-safe flex items-center justify-center bg-white'>
+        <div className='text-gray-500'>로딩 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='bg-gray-0 min-h-screen-safe mx-auto flex w-full max-w-screen-sm flex-col'>
+      <TopBar
+        title='일정 수정하기'
+        leftIcon='arrow_prev'
+        onLeftClick={handleBack}
+      />
+      <Header variant='subHeader' title={'가능한 시간을\n다시 선택해주세요'} />
+
+      <main className='flex flex-1 flex-col pt-1 pb-10'>
+        <div className='@container relative flex-1'>
+          <TimeSlotGrid
+            dates={dates}
+            timeRange={timeRange}
+            isSelected={isSelected}
+            beginDrag={beginDrag}
+            updateDrag={updateDrag}
+            endDrag={endDrag}
+          />
+        </div>
+
+        <div className='mt-6 mb-6 px-5'>
+          <div
+            className='flex cursor-pointer items-center gap-2'
+            onClick={() => handleAllImpossibleChange(!isAllImpossible)}
+          >
+            <Checkbox checked={isAllImpossible} onChange={() => {}} />
+            <span className='text-body-4 text-text-secondary select-none'>
+              모든 날짜에 참여가 어려워요
+            </span>
+          </div>
+        </div>
+
+        <div className='px-5'>
+          <Button
+            onClick={handleSubmitWithTracking}
+            disabled={!isCtaActive}
+            fullWidth
+          >
+            수정하기
+          </Button>
+        </div>
+      </main>
+
+      <SuccessBottomSheet
+        isOpen={isSuccessModalOpen}
+        onClose={handleSuccessModalCloseWithTracking}
+        onConfirm={handleSuccessModalCloseWithTracking}
+        title={'투표가 수정되었어요!'}
+        subtitle={'지금 투표 현황을 확인해보세요'}
+      />
+    </div>
+  );
+}

--- a/src/features/participant-register-time-slot/ui/ParticipantRegisterTimeSlotPage.tsx
+++ b/src/features/participant-register-time-slot/ui/ParticipantRegisterTimeSlotPage.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useParticipantRegisterTimeSlot } from '@/features/participant-register-time-slot/model/useParticipantRegisterTimeSlot';
+import TimeSlotGrid from '@/features/participant-register-time-slot/ui/TimeSlotGrid';
+import { trackEvent } from '@/shared/lib/amplitude';
+import SuccessBottomSheet from '@/shared/ui/bottom-sheet/SuccessBottomSheet';
+import Button from '@/shared/ui/button/Button';
+import Checkbox from '@/shared/ui/checkbox/Checkbox';
+import { Header } from '@/shared/ui/header/Header';
+import TopBar from '@/shared/ui/top-bar/TopBar';
+
+interface ParticipantRegisterTimeSlotPageProps {
+  meetingId: string;
+}
+
+export default function ParticipantRegisterTimeSlotPage({
+  meetingId,
+}: ParticipantRegisterTimeSlotPageProps) {
+  const {
+    isLoading,
+    dates,
+    timeRange,
+    isAllImpossible,
+    isCtaActive,
+    isSelected,
+    beginDrag,
+    updateDrag,
+    endDrag,
+    handleAllImpossibleChange,
+    handleBack,
+    handleSubmit,
+    isSuccessModalOpen,
+    handleSuccessModalClose,
+  } = useParticipantRegisterTimeSlot(meetingId);
+
+  const handleSubmitWithTracking = () => {
+    trackEvent('voter_vote_cta_click');
+    handleSubmit();
+  };
+
+  const handleSuccessModalCloseWithTracking = () => {
+    trackEvent('voter_vote_completed_cta_click');
+    handleSuccessModalClose();
+  };
+
+  if (isLoading || !timeRange) {
+    return (
+      <div className='min-h-screen-safe flex items-center justify-center bg-white'>
+        <div className='text-gray-500'>로딩 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='bg-gray-0 min-h-screen-safe mx-auto flex w-full max-w-screen-sm flex-col'>
+      <TopBar
+        title='일정 투표하기'
+        leftIcon='arrow_prev'
+        onLeftClick={handleBack}
+      />
+      <Header variant='subHeader' title={'가능한 시간을\n모두 선택해주세요'} />
+
+      <main className='flex flex-1 flex-col pt-1 pb-10'>
+        <div className='@container relative flex-1'>
+          <TimeSlotGrid
+            dates={dates}
+            timeRange={timeRange}
+            isSelected={isSelected}
+            beginDrag={beginDrag}
+            updateDrag={updateDrag}
+            endDrag={endDrag}
+          />
+        </div>
+
+        <div className='mt-6 mb-6 px-5'>
+          <div
+            className='flex cursor-pointer items-center gap-2'
+            onClick={() => handleAllImpossibleChange(!isAllImpossible)}
+          >
+            <Checkbox checked={isAllImpossible} onChange={() => {}} />
+            <span className='text-body-4 text-text-secondary select-none'>
+              모든 날짜에 참여가 어려워요
+            </span>
+          </div>
+        </div>
+
+        <div className='px-5'>
+          <Button
+            onClick={handleSubmitWithTracking}
+            disabled={!isCtaActive}
+            fullWidth
+          >
+            투표하기
+          </Button>
+        </div>
+      </main>
+
+      <SuccessBottomSheet
+        isOpen={isSuccessModalOpen}
+        onClose={handleSuccessModalCloseWithTracking}
+        onConfirm={handleSuccessModalCloseWithTracking}
+        title={'투표가 완료되었어요!'}
+        subtitle={'지금 투표 현황을 확인해보세요'}
+      />
+    </div>
+  );
+}

--- a/src/features/participant-register-time-slot/ui/TimeSlotCell.tsx
+++ b/src/features/participant-register-time-slot/ui/TimeSlotCell.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+interface TimeSlotCellProps {
+  dateIndex: number;
+  slotIndex: number;
+  isSelected: boolean;
+  height: number;
+  onPointerDown: (dateIndex: number, slotIndex: number) => void;
+  onPointerEnter: (dateIndex: number, slotIndex: number) => void;
+}
+
+// 입력 화면 BASE 톤 (시안 기준): 결과 페이지의 4% opacity 보다 진하게.
+// 시안에서 1시간 박스 rounded-[10px] 윤곽이 명확히 보이는 정도.
+const INPUT_BASE_TONE = 'bg-[#F1F5FB]';
+
+export default function TimeSlotCell({
+  dateIndex,
+  slotIndex,
+  isSelected,
+  height,
+  onPointerDown,
+  onPointerEnter,
+}: TimeSlotCellProps) {
+  const colorClass = isSelected ? 'bg-[#3C7EFA]' : INPUT_BASE_TONE;
+
+  return (
+    <button
+      type='button'
+      role='gridcell'
+      data-date-index={dateIndex}
+      data-slot-index={slotIndex}
+      aria-selected={isSelected}
+      onPointerDown={(e) => {
+        e.preventDefault();
+        // pointer capture 로 드래그 중 포인터가 다른 셀 위로 이동해도 동일 셀이 이벤트 받음.
+        // 일부 환경(synthetic event 등) 에서는 메서드 미지원 — optional chaining 으로 안전 처리.
+        e.currentTarget.setPointerCapture?.(e.pointerId);
+        onPointerDown(dateIndex, slotIndex);
+      }}
+      onPointerEnter={() => onPointerEnter(dateIndex, slotIndex)}
+      style={{ height }}
+      className={`box-border w-full cursor-pointer touch-none select-none ${colorClass}`}
+    />
+  );
+}

--- a/src/features/participant-register-time-slot/ui/TimeSlotCell.tsx
+++ b/src/features/participant-register-time-slot/ui/TimeSlotCell.tsx
@@ -5,41 +5,49 @@ interface TimeSlotCellProps {
   slotIndex: number;
   isSelected: boolean;
   height: number;
-  onPointerDown: (dateIndex: number, slotIndex: number) => void;
-  onPointerEnter: (dateIndex: number, slotIndex: number) => void;
+  /** 모임 timeRange 외 셀은 disabled (클릭/드래그 불가, 더 옅은 톤). */
+  disabled?: boolean;
 }
 
 // 입력 화면 BASE 톤 (시안 기준): 결과 페이지의 4% opacity 보다 진하게.
 // 시안에서 1시간 박스 rounded-[10px] 윤곽이 명확히 보이는 정도.
 const INPUT_BASE_TONE = 'bg-[#F1F5FB]';
+// timeRange 외 (모임 시간이 아닌 슬롯) 톤 — 더 옅게 + 점선 격자 인상
+const DISABLED_TONE = 'bg-gray-50';
 
+/**
+ * 시간 슬롯 그리드 셀.
+ * pointer 이벤트는 부모 `TimeSlotGrid` 가 elementFromPoint 로 처리한다
+ * (셀 별로 setPointerCapture 를 사용하면 origin 셀이 후속 이벤트를 독점해서
+ * 다른 셀에 진입해도 드래그가 퍼지지 않는 문제 회피).
+ */
 export default function TimeSlotCell({
   dateIndex,
   slotIndex,
   isSelected,
   height,
-  onPointerDown,
-  onPointerEnter,
+  disabled = false,
 }: TimeSlotCellProps) {
-  const colorClass = isSelected ? 'bg-[#3C7EFA]' : INPUT_BASE_TONE;
+  const colorClass = disabled
+    ? DISABLED_TONE
+    : isSelected
+      ? 'bg-[#3C7EFA]'
+      : INPUT_BASE_TONE;
 
   return (
     <button
       type='button'
       role='gridcell'
-      data-date-index={dateIndex}
-      data-slot-index={slotIndex}
-      aria-selected={isSelected}
-      onPointerDown={(e) => {
-        e.preventDefault();
-        // pointer capture 로 드래그 중 포인터가 다른 셀 위로 이동해도 동일 셀이 이벤트 받음.
-        // 일부 환경(synthetic event 등) 에서는 메서드 미지원 — optional chaining 으로 안전 처리.
-        e.currentTarget.setPointerCapture?.(e.pointerId);
-        onPointerDown(dateIndex, slotIndex);
-      }}
-      onPointerEnter={() => onPointerEnter(dateIndex, slotIndex)}
+      tabIndex={-1}
+      data-date-index={disabled ? undefined : dateIndex}
+      data-slot-index={disabled ? undefined : slotIndex}
+      data-disabled={disabled || undefined}
+      aria-selected={!disabled && isSelected}
+      aria-disabled={disabled || undefined}
       style={{ height }}
-      className={`box-border w-full cursor-pointer touch-none select-none ${colorClass}`}
+      className={`box-border w-full select-none ${
+        disabled ? 'cursor-not-allowed' : 'cursor-pointer'
+      } ${colorClass}`}
     />
   );
 }

--- a/src/features/participant-register-time-slot/ui/TimeSlotCell.tsx
+++ b/src/features/participant-register-time-slot/ui/TimeSlotCell.tsx
@@ -5,15 +5,11 @@ interface TimeSlotCellProps {
   slotIndex: number;
   isSelected: boolean;
   height: number;
-  /** 모임 timeRange 외 셀은 disabled (클릭/드래그 불가, 더 옅은 톤). */
-  disabled?: boolean;
 }
 
 // 입력 화면 BASE 톤 (시안 기준): 결과 페이지의 4% opacity 보다 진하게.
 // 시안에서 1시간 박스 rounded-[10px] 윤곽이 명확히 보이는 정도.
 const INPUT_BASE_TONE = 'bg-[#F1F5FB]';
-// timeRange 외 (모임 시간이 아닌 슬롯) 톤 — 더 옅게 + 점선 격자 인상
-const DISABLED_TONE = 'bg-gray-50';
 
 /**
  * 시간 슬롯 그리드 셀.
@@ -26,28 +22,19 @@ export default function TimeSlotCell({
   slotIndex,
   isSelected,
   height,
-  disabled = false,
 }: TimeSlotCellProps) {
-  const colorClass = disabled
-    ? DISABLED_TONE
-    : isSelected
-      ? 'bg-[#3C7EFA]'
-      : INPUT_BASE_TONE;
+  const colorClass = isSelected ? 'bg-[#3C7EFA]' : INPUT_BASE_TONE;
 
   return (
     <button
       type='button'
       role='gridcell'
       tabIndex={-1}
-      data-date-index={disabled ? undefined : dateIndex}
-      data-slot-index={disabled ? undefined : slotIndex}
-      data-disabled={disabled || undefined}
-      aria-selected={!disabled && isSelected}
-      aria-disabled={disabled || undefined}
+      data-date-index={dateIndex}
+      data-slot-index={slotIndex}
+      aria-selected={isSelected}
       style={{ height }}
-      className={`box-border w-full select-none ${
-        disabled ? 'cursor-not-allowed' : 'cursor-pointer'
-      } ${colorClass}`}
+      className={`box-border w-full cursor-pointer select-none ${colorClass}`}
     />
   );
 }

--- a/src/features/participant-register-time-slot/ui/TimeSlotGrid.tsx
+++ b/src/features/participant-register-time-slot/ui/TimeSlotGrid.tsx
@@ -1,15 +1,27 @@
 'use client';
 
+import { isSameWeek } from 'date-fns';
+import { type PointerEvent as ReactPointerEvent, useRef } from 'react';
+
 import { type TimeRangeWithSlotCount } from '@/entities/meet/dto/meet.dto';
 import TimeSlotCell from '@/features/participant-register-time-slot/ui/TimeSlotCell';
+import {
+  END_HOUR,
+  SLOTS_PER_HOUR,
+  START_HOUR,
+  TOTAL_SLOTS,
+} from '@/shared/config/timeSlot';
 import { parseDate } from '@/shared/lib/date';
 
 const SLOT_H = 40;
-const HOUR_H = SLOT_H * 2;
+const HOUR_H = SLOT_H * SLOTS_PER_HOUR;
 const TIME_COL_W = 40;
 const DAY_HEADER_H = 56;
 const COL_GAP = 4;
 const ROW_GAP = 4;
+// 인접 컬럼이 서로 다른 ISO 주(월~일) 에 속할 때 일반 갭 위에 추가로 더하는 마진.
+// 시안 (Figma 3627:6155) 기준 토 → 월 같이 주가 바뀌는 경계에 시각 단서를 준다.
+const WEEK_GAP_EXTRA = 12;
 const GRID_PADDING_X = 20;
 // 컬럼 가시성 분기:
 // - 5개 이상: 4.5 컬럼만 노출 (우측 컷오프로 더 있음을 시사) — PR #71 결과 표와 동일
@@ -47,6 +59,44 @@ function timeToMinutes(t: string): number {
   return hh * 60 + mm;
 }
 
+/**
+ * Display 인덱스(9~21시 24슬롯, PR #71 결과 표와 동일 layout) 를 모임 timeRange 인덱스로 변환.
+ * - timeRange 안에 들어가는 display slot → meeting slotIndex 반환
+ * - timeRange 외 (모임 시간이 아닌 슬롯) → null (셀 disabled, 클릭 불가)
+ */
+function displayToMeetingSlot(
+  displayIdx: number,
+  meetingStartMin: number,
+  meetingEndMin: number,
+): number | null {
+  const slotStartMin = START_HOUR * 60 + displayIdx * (60 / SLOTS_PER_HOUR);
+  if (slotStartMin < meetingStartMin) return null;
+  if (slotStartMin >= meetingEndMin) return null;
+  return (slotStartMin - meetingStartMin) / (60 / SLOTS_PER_HOUR);
+}
+
+/**
+ * `clientX/clientY` 위치의 셀 좌표(`dateIndex`, `slotIndex`) 를 추출.
+ * data attribute 로 셀을 식별. timeRange 외 disabled 셀은 data-disabled='true' 로 표시되며 null 반환.
+ */
+function getCellAtPoint(
+  x: number,
+  y: number,
+): {
+  dateIndex: number;
+  slotIndex: number;
+} | null {
+  const el = document.elementFromPoint(x, y);
+  if (!el) return null;
+  const cellEl = el.closest('[data-date-index]') as HTMLElement | null;
+  if (!cellEl) return null;
+  if (cellEl.dataset.disabled === 'true') return null;
+  const dateIndex = Number(cellEl.dataset.dateIndex);
+  const slotIndex = Number(cellEl.dataset.slotIndex);
+  if (Number.isNaN(dateIndex) || Number.isNaN(slotIndex)) return null;
+  return { dateIndex, slotIndex };
+}
+
 export default function TimeSlotGrid({
   dates,
   timeRange,
@@ -55,58 +105,60 @@ export default function TimeSlotGrid({
   updateDrag,
   endDrag,
 }: TimeSlotGridProps) {
-  // timeRange 의 startTime ~ endTime 만 표시.
-  // 1시간 = 2 슬롯 그룹으로 묶음 (PR #71 결과 표와 동일 layout).
-  const startMin = timeToMinutes(timeRange.startTime);
-  const startHour = Math.floor(startMin / 60);
-  const startHasHalfOffset = startMin % 60 === 30;
+  const meetingStartMin = timeToMinutes(timeRange.startTime);
+  const meetingEndMin = timeToMinutes(timeRange.endTime);
 
-  // 표시할 정시(hour) 라벨 — 시작 시각이 30분이면 그 다음 정시부터.
-  const endMin = timeToMinutes(timeRange.endTime);
-  const endHour = Math.ceil(endMin / 60);
-
-  // 한 시간 단위로 그룹핑한 [topSlotIdx, botSlotIdx, hourLabel] 목록
-  // 시작이 30분 오프셋이면 첫 그룹은 한 슬롯만.
-  const groups: Array<{
-    hour: number;
-    topSlotIdx: number | null;
-    botSlotIdx: number | null;
-  }> = [];
-  let cursor = 0;
-  if (startHasHalfOffset) {
-    groups.push({
-      hour: startHour,
-      topSlotIdx: null,
-      botSlotIdx: cursor,
-    });
-    cursor += 1;
-  }
-  for (
-    let h = startHasHalfOffset ? startHour + 1 : startHour;
-    h < endHour;
-    h += 1
-  ) {
-    const top = cursor;
-    const bot = cursor + 1;
-    groups.push({
-      hour: h,
-      topSlotIdx: top,
-      botSlotIdx: bot < timeRange.slotCount ? bot : null,
-    });
-    cursor += 2;
-  }
+  // 1시간 = 2 슬롯 그룹으로 묶음. PR #71 결과 표와 동일 layout (9~21 24슬롯 고정).
+  const hours = Array.from(
+    { length: END_HOUR - START_HOUR },
+    (_, i) => START_HOUR + i,
+  );
 
   const colWidth = buildColWidth(dates.length);
+
+  // 마지막 드래그 셀 좌표 — 같은 셀에서 pointermove 가 반복되어도 updateDrag 재호출 방지.
+  const lastCellRef = useRef<{ dateIndex: number; slotIndex: number } | null>(
+    null,
+  );
+
+  const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const cell = getCellAtPoint(e.clientX, e.clientY);
+    if (!cell) return;
+    e.preventDefault();
+    e.currentTarget.setPointerCapture?.(e.pointerId);
+    lastCellRef.current = cell;
+    beginDrag(cell.dateIndex, cell.slotIndex);
+  };
+
+  const handlePointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (lastCellRef.current === null) return;
+    const cell = getCellAtPoint(e.clientX, e.clientY);
+    if (!cell) return;
+    const last = lastCellRef.current;
+    if (last.dateIndex === cell.dateIndex && last.slotIndex === cell.slotIndex)
+      return;
+    lastCellRef.current = cell;
+    updateDrag(cell.dateIndex, cell.slotIndex);
+  };
+
+  const handlePointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
+    lastCellRef.current = null;
+    endDrag();
+    if (e.currentTarget.hasPointerCapture?.(e.pointerId)) {
+      e.currentTarget.releasePointerCapture?.(e.pointerId);
+    }
+  };
 
   return (
     <div
       role='grid'
-      aria-rowcount={timeRange.slotCount + 1}
+      aria-rowcount={TOTAL_SLOTS + 1}
       aria-colcount={dates.length + 1}
-      className='flex w-full overflow-auto px-5 pb-5'
-      onPointerUp={endDrag}
-      onPointerCancel={endDrag}
-      onPointerLeave={endDrag}
+      className='flex w-full touch-none overflow-auto pb-5'
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
     >
       <div
         className='sticky left-0 z-20 shrink-0 bg-white'
@@ -114,14 +166,14 @@ export default function TimeSlotGrid({
       >
         <div style={{ height: DAY_HEADER_H }} />
         <div className='flex flex-col' style={{ gap: ROW_GAP }}>
-          {groups.map((group) => (
+          {hours.map((hour) => (
             <div
-              key={group.hour}
+              key={hour}
               role='rowheader'
               style={{ height: HOUR_H }}
               className='text-text-tertiary flex items-start justify-end pr-2 text-[14px] leading-5 font-medium'
             >
-              {group.hour}
+              {hour}
             </div>
           ))}
         </div>
@@ -132,9 +184,22 @@ export default function TimeSlotGrid({
           const { weekday, md } = formatDateHeader(date);
           const dow = parseDate(date).getDay();
           const isWeekend = dow === 0 || dow === 6;
+          const prevDate = dateIndex > 0 ? dates[dateIndex - 1] : null;
+          const isWeekChange =
+            prevDate !== null &&
+            !isSameWeek(parseDate(prevDate), parseDate(date), {
+              weekStartsOn: 1,
+            });
 
           return (
-            <div key={date} className='shrink-0' style={{ width: colWidth }}>
+            <div
+              key={date}
+              className='shrink-0'
+              style={{
+                width: colWidth,
+                marginLeft: isWeekChange ? WEEK_GAP_EXTRA : undefined,
+              }}
+            >
               <div
                 role='columnheader'
                 style={{ height: DAY_HEADER_H }}
@@ -153,43 +218,54 @@ export default function TimeSlotGrid({
               </div>
 
               <div className='flex flex-col' style={{ gap: ROW_GAP }}>
-                {groups.map((group) => (
-                  <div
-                    key={`${date}-${group.hour}`}
-                    role='row'
-                    className='overflow-hidden rounded-[10px]'
-                    style={{ height: HOUR_H }}
-                  >
-                    {group.topSlotIdx !== null ? (
-                      <TimeSlotCell
-                        dateIndex={dateIndex}
-                        slotIndex={group.topSlotIdx}
-                        isSelected={isSelected(dateIndex, group.topSlotIdx)}
-                        height={SLOT_H}
-                        onPointerDown={beginDrag}
-                        onPointerEnter={updateDrag}
-                      />
-                    ) : (
-                      <div style={{ height: SLOT_H }} />
-                    )}
+                {hours.map((_, hourIdx) => {
+                  const topDisplayIdx = hourIdx * SLOTS_PER_HOUR;
+                  const botDisplayIdx = hourIdx * SLOTS_PER_HOUR + 1;
+                  const topMeetingIdx = displayToMeetingSlot(
+                    topDisplayIdx,
+                    meetingStartMin,
+                    meetingEndMin,
+                  );
+                  const botMeetingIdx = displayToMeetingSlot(
+                    botDisplayIdx,
+                    meetingStartMin,
+                    meetingEndMin,
+                  );
+
+                  return (
                     <div
-                      className='border-t border-dashed border-white/40'
-                      style={{ marginTop: -1 }}
-                    />
-                    {group.botSlotIdx !== null ? (
+                      key={`${date}-${hourIdx}`}
+                      role='row'
+                      className='overflow-hidden rounded-[10px]'
+                      style={{ height: HOUR_H }}
+                    >
                       <TimeSlotCell
                         dateIndex={dateIndex}
-                        slotIndex={group.botSlotIdx}
-                        isSelected={isSelected(dateIndex, group.botSlotIdx)}
+                        slotIndex={topMeetingIdx ?? -1}
+                        isSelected={
+                          topMeetingIdx !== null &&
+                          isSelected(dateIndex, topMeetingIdx)
+                        }
                         height={SLOT_H}
-                        onPointerDown={beginDrag}
-                        onPointerEnter={updateDrag}
+                        disabled={topMeetingIdx === null}
                       />
-                    ) : (
-                      <div style={{ height: SLOT_H }} />
-                    )}
-                  </div>
-                ))}
+                      <div
+                        className='border-t border-dashed border-white/40'
+                        style={{ marginTop: -1 }}
+                      />
+                      <TimeSlotCell
+                        dateIndex={dateIndex}
+                        slotIndex={botMeetingIdx ?? -1}
+                        isSelected={
+                          botMeetingIdx !== null &&
+                          isSelected(dateIndex, botMeetingIdx)
+                        }
+                        height={SLOT_H}
+                        disabled={botMeetingIdx === null}
+                      />
+                    </div>
+                  );
+                })}
               </div>
             </div>
           );

--- a/src/features/participant-register-time-slot/ui/TimeSlotGrid.tsx
+++ b/src/features/participant-register-time-slot/ui/TimeSlotGrid.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { type TimeRangeWithSlotCount } from '@/entities/meet/dto/meet.dto';
+import TimeSlotCell from '@/features/participant-register-time-slot/ui/TimeSlotCell';
+import { parseDate } from '@/shared/lib/date';
+
+const SLOT_H = 40;
+const HOUR_H = SLOT_H * 2;
+const TIME_COL_W = 40;
+const DAY_HEADER_H = 56;
+const COL_GAP = 4;
+const ROW_GAP = 4;
+const GRID_PADDING_X = 20;
+// 컬럼 가시성 분기:
+// - 5개 이상: 4.5 컬럼만 노출 (우측 컷오프로 더 있음을 시사) — PR #71 결과 표와 동일
+// - 4개 이하: 화면 폭에 균등 분배 (가로 스크롤 없이 모두 보임)
+function buildColWidth(dateCount: number): string {
+  if (dateCount >= 5) {
+    const visibleCols = 4.5;
+    const visibleGaps = 4;
+    return `calc((100cqi - ${GRID_PADDING_X * 2 + TIME_COL_W + COL_GAP * visibleGaps}px) / ${visibleCols})`;
+  }
+  const gaps = Math.max(0, dateCount - 1);
+  return `calc((100cqi - ${GRID_PADDING_X * 2 + TIME_COL_W + COL_GAP * gaps}px) / ${dateCount})`;
+}
+
+const WEEK_KO = ['일', '월', '화', '수', '목', '금', '토'];
+
+function formatDateHeader(dateStr: string): { weekday: string; md: string } {
+  const d = parseDate(dateStr);
+  const month = (d.getMonth() + 1).toString().padStart(2, '0');
+  const day = d.getDate().toString().padStart(2, '0');
+  return { weekday: WEEK_KO[d.getDay()], md: `${month}.${day}` };
+}
+
+interface TimeSlotGridProps {
+  dates: string[];
+  timeRange: TimeRangeWithSlotCount;
+  isSelected: (dateIndex: number, slotIndex: number) => boolean;
+  beginDrag: (dateIndex: number, slotIndex: number) => void;
+  updateDrag: (dateIndex: number, slotIndex: number) => void;
+  endDrag: () => void;
+}
+
+function timeToMinutes(t: string): number {
+  const [hh, mm] = t.split(':').map(Number);
+  return hh * 60 + mm;
+}
+
+export default function TimeSlotGrid({
+  dates,
+  timeRange,
+  isSelected,
+  beginDrag,
+  updateDrag,
+  endDrag,
+}: TimeSlotGridProps) {
+  // timeRange 의 startTime ~ endTime 만 표시.
+  // 1시간 = 2 슬롯 그룹으로 묶음 (PR #71 결과 표와 동일 layout).
+  const startMin = timeToMinutes(timeRange.startTime);
+  const startHour = Math.floor(startMin / 60);
+  const startHasHalfOffset = startMin % 60 === 30;
+
+  // 표시할 정시(hour) 라벨 — 시작 시각이 30분이면 그 다음 정시부터.
+  const endMin = timeToMinutes(timeRange.endTime);
+  const endHour = Math.ceil(endMin / 60);
+
+  // 한 시간 단위로 그룹핑한 [topSlotIdx, botSlotIdx, hourLabel] 목록
+  // 시작이 30분 오프셋이면 첫 그룹은 한 슬롯만.
+  const groups: Array<{
+    hour: number;
+    topSlotIdx: number | null;
+    botSlotIdx: number | null;
+  }> = [];
+  let cursor = 0;
+  if (startHasHalfOffset) {
+    groups.push({
+      hour: startHour,
+      topSlotIdx: null,
+      botSlotIdx: cursor,
+    });
+    cursor += 1;
+  }
+  for (
+    let h = startHasHalfOffset ? startHour + 1 : startHour;
+    h < endHour;
+    h += 1
+  ) {
+    const top = cursor;
+    const bot = cursor + 1;
+    groups.push({
+      hour: h,
+      topSlotIdx: top,
+      botSlotIdx: bot < timeRange.slotCount ? bot : null,
+    });
+    cursor += 2;
+  }
+
+  const colWidth = buildColWidth(dates.length);
+
+  return (
+    <div
+      role='grid'
+      aria-rowcount={timeRange.slotCount + 1}
+      aria-colcount={dates.length + 1}
+      className='flex w-full overflow-auto px-5 pb-5'
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onPointerLeave={endDrag}
+    >
+      <div
+        className='sticky left-0 z-20 shrink-0 bg-white'
+        style={{ width: TIME_COL_W }}
+      >
+        <div style={{ height: DAY_HEADER_H }} />
+        <div className='flex flex-col' style={{ gap: ROW_GAP }}>
+          {groups.map((group) => (
+            <div
+              key={group.hour}
+              role='rowheader'
+              style={{ height: HOUR_H }}
+              className='text-text-tertiary flex items-start justify-end pr-2 text-[14px] leading-5 font-medium'
+            >
+              {group.hour}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className='flex' style={{ gap: COL_GAP }}>
+        {dates.map((date, dateIndex) => {
+          const { weekday, md } = formatDateHeader(date);
+          const dow = parseDate(date).getDay();
+          const isWeekend = dow === 0 || dow === 6;
+
+          return (
+            <div key={date} className='shrink-0' style={{ width: colWidth }}>
+              <div
+                role='columnheader'
+                style={{ height: DAY_HEADER_H }}
+                className='sticky top-0 z-10 flex flex-col items-center justify-center gap-1 bg-white'
+              >
+                <span
+                  className={`text-[12px] font-semibold ${
+                    isWeekend ? 'text-red-400' : 'text-text-tertiary'
+                  }`}
+                >
+                  {weekday}
+                </span>
+                <span className='text-text-secondary text-[14px] font-semibold'>
+                  {md}
+                </span>
+              </div>
+
+              <div className='flex flex-col' style={{ gap: ROW_GAP }}>
+                {groups.map((group) => (
+                  <div
+                    key={`${date}-${group.hour}`}
+                    role='row'
+                    className='overflow-hidden rounded-[10px]'
+                    style={{ height: HOUR_H }}
+                  >
+                    {group.topSlotIdx !== null ? (
+                      <TimeSlotCell
+                        dateIndex={dateIndex}
+                        slotIndex={group.topSlotIdx}
+                        isSelected={isSelected(dateIndex, group.topSlotIdx)}
+                        height={SLOT_H}
+                        onPointerDown={beginDrag}
+                        onPointerEnter={updateDrag}
+                      />
+                    ) : (
+                      <div style={{ height: SLOT_H }} />
+                    )}
+                    <div
+                      className='border-t border-dashed border-white/40'
+                      style={{ marginTop: -1 }}
+                    />
+                    {group.botSlotIdx !== null ? (
+                      <TimeSlotCell
+                        dateIndex={dateIndex}
+                        slotIndex={group.botSlotIdx}
+                        isSelected={isSelected(dateIndex, group.botSlotIdx)}
+                        height={SLOT_H}
+                        onPointerDown={beginDrag}
+                        onPointerEnter={updateDrag}
+                      />
+                    ) : (
+                      <div style={{ height: SLOT_H }} />
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/features/participant-register-time-slot/ui/TimeSlotGrid.tsx
+++ b/src/features/participant-register-time-slot/ui/TimeSlotGrid.tsx
@@ -5,16 +5,10 @@ import { type PointerEvent as ReactPointerEvent, useRef } from 'react';
 
 import { type TimeRangeWithSlotCount } from '@/entities/meet/dto/meet.dto';
 import TimeSlotCell from '@/features/participant-register-time-slot/ui/TimeSlotCell';
-import {
-  END_HOUR,
-  SLOTS_PER_HOUR,
-  START_HOUR,
-  TOTAL_SLOTS,
-} from '@/shared/config/timeSlot';
 import { parseDate } from '@/shared/lib/date';
 
 const SLOT_H = 40;
-const HOUR_H = SLOT_H * SLOTS_PER_HOUR;
+const HOUR_H = SLOT_H * 2;
 const TIME_COL_W = 40;
 const DAY_HEADER_H = 56;
 const COL_GAP = 4;
@@ -24,7 +18,7 @@ const ROW_GAP = 4;
 const WEEK_GAP_EXTRA = 12;
 const GRID_PADDING_X = 20;
 // 컬럼 가시성 분기:
-// - 5개 이상: 4.5 컬럼만 노출 (우측 컷오프로 더 있음을 시사) — PR #71 결과 표와 동일
+// - 5개 이상: 4.5 컬럼만 노출 (우측 컷오프로 더 있음을 시사)
 // - 4개 이하: 화면 폭에 균등 분배 (가로 스크롤 없이 모두 보임)
 function buildColWidth(dateCount: number): string {
   if (dateCount >= 5) {
@@ -60,24 +54,8 @@ function timeToMinutes(t: string): number {
 }
 
 /**
- * Display 인덱스(9~21시 24슬롯, PR #71 결과 표와 동일 layout) 를 모임 timeRange 인덱스로 변환.
- * - timeRange 안에 들어가는 display slot → meeting slotIndex 반환
- * - timeRange 외 (모임 시간이 아닌 슬롯) → null (셀 disabled, 클릭 불가)
- */
-function displayToMeetingSlot(
-  displayIdx: number,
-  meetingStartMin: number,
-  meetingEndMin: number,
-): number | null {
-  const slotStartMin = START_HOUR * 60 + displayIdx * (60 / SLOTS_PER_HOUR);
-  if (slotStartMin < meetingStartMin) return null;
-  if (slotStartMin >= meetingEndMin) return null;
-  return (slotStartMin - meetingStartMin) / (60 / SLOTS_PER_HOUR);
-}
-
-/**
  * `clientX/clientY` 위치의 셀 좌표(`dateIndex`, `slotIndex`) 를 추출.
- * data attribute 로 셀을 식별. timeRange 외 disabled 셀은 data-disabled='true' 로 표시되며 null 반환.
+ * data attribute 로 셀을 식별. 셀 외 영역(헤더/시간 컬럼/패딩) 이면 null.
  */
 function getCellAtPoint(
   x: number,
@@ -90,7 +68,6 @@ function getCellAtPoint(
   if (!el) return null;
   const cellEl = el.closest('[data-date-index]') as HTMLElement | null;
   if (!cellEl) return null;
-  if (cellEl.dataset.disabled === 'true') return null;
   const dateIndex = Number(cellEl.dataset.dateIndex);
   const slotIndex = Number(cellEl.dataset.slotIndex);
   if (Number.isNaN(dateIndex) || Number.isNaN(slotIndex)) return null;
@@ -105,14 +82,44 @@ export default function TimeSlotGrid({
   updateDrag,
   endDrag,
 }: TimeSlotGridProps) {
-  const meetingStartMin = timeToMinutes(timeRange.startTime);
-  const meetingEndMin = timeToMinutes(timeRange.endTime);
+  // timeRange 의 startTime ~ endTime 만 표시.
+  // 1시간 = 2 슬롯 그룹으로 묶음.
+  const startMin = timeToMinutes(timeRange.startTime);
+  const startHour = Math.floor(startMin / 60);
+  const startHasHalfOffset = startMin % 60 === 30;
 
-  // 1시간 = 2 슬롯 그룹으로 묶음. PR #71 결과 표와 동일 layout (9~21 24슬롯 고정).
-  const hours = Array.from(
-    { length: END_HOUR - START_HOUR },
-    (_, i) => START_HOUR + i,
-  );
+  const endMin = timeToMinutes(timeRange.endTime);
+  const endHour = Math.ceil(endMin / 60);
+
+  // 시작이 30분 오프셋이면 첫 그룹은 한 슬롯만 (botSlot 만).
+  const groups: Array<{
+    hour: number;
+    topSlotIdx: number | null;
+    botSlotIdx: number | null;
+  }> = [];
+  let cursor = 0;
+  if (startHasHalfOffset) {
+    groups.push({
+      hour: startHour,
+      topSlotIdx: null,
+      botSlotIdx: cursor,
+    });
+    cursor += 1;
+  }
+  for (
+    let h = startHasHalfOffset ? startHour + 1 : startHour;
+    h < endHour;
+    h += 1
+  ) {
+    const top = cursor;
+    const bot = cursor + 1;
+    groups.push({
+      hour: h,
+      topSlotIdx: top,
+      botSlotIdx: bot < timeRange.slotCount ? bot : null,
+    });
+    cursor += 2;
+  }
 
   const colWidth = buildColWidth(dates.length);
 
@@ -152,7 +159,7 @@ export default function TimeSlotGrid({
   return (
     <div
       role='grid'
-      aria-rowcount={TOTAL_SLOTS + 1}
+      aria-rowcount={timeRange.slotCount + 1}
       aria-colcount={dates.length + 1}
       className='flex w-full touch-none overflow-auto pb-5'
       onPointerDown={handlePointerDown}
@@ -166,14 +173,14 @@ export default function TimeSlotGrid({
       >
         <div style={{ height: DAY_HEADER_H }} />
         <div className='flex flex-col' style={{ gap: ROW_GAP }}>
-          {hours.map((hour) => (
+          {groups.map((group) => (
             <div
-              key={hour}
+              key={group.hour}
               role='rowheader'
               style={{ height: HOUR_H }}
               className='text-text-tertiary flex items-start justify-end pr-2 text-[14px] leading-5 font-medium'
             >
-              {hour}
+              {group.hour}
             </div>
           ))}
         </div>
@@ -218,54 +225,39 @@ export default function TimeSlotGrid({
               </div>
 
               <div className='flex flex-col' style={{ gap: ROW_GAP }}>
-                {hours.map((_, hourIdx) => {
-                  const topDisplayIdx = hourIdx * SLOTS_PER_HOUR;
-                  const botDisplayIdx = hourIdx * SLOTS_PER_HOUR + 1;
-                  const topMeetingIdx = displayToMeetingSlot(
-                    topDisplayIdx,
-                    meetingStartMin,
-                    meetingEndMin,
-                  );
-                  const botMeetingIdx = displayToMeetingSlot(
-                    botDisplayIdx,
-                    meetingStartMin,
-                    meetingEndMin,
-                  );
-
-                  return (
+                {groups.map((group) => (
+                  <div
+                    key={`${date}-${group.hour}`}
+                    role='row'
+                    className='overflow-hidden rounded-[10px]'
+                    style={{ height: HOUR_H }}
+                  >
+                    {group.topSlotIdx !== null ? (
+                      <TimeSlotCell
+                        dateIndex={dateIndex}
+                        slotIndex={group.topSlotIdx}
+                        isSelected={isSelected(dateIndex, group.topSlotIdx)}
+                        height={SLOT_H}
+                      />
+                    ) : (
+                      <div style={{ height: SLOT_H }} />
+                    )}
                     <div
-                      key={`${date}-${hourIdx}`}
-                      role='row'
-                      className='overflow-hidden rounded-[10px]'
-                      style={{ height: HOUR_H }}
-                    >
+                      className='border-t border-dashed border-white/40'
+                      style={{ marginTop: -1 }}
+                    />
+                    {group.botSlotIdx !== null ? (
                       <TimeSlotCell
                         dateIndex={dateIndex}
-                        slotIndex={topMeetingIdx ?? -1}
-                        isSelected={
-                          topMeetingIdx !== null &&
-                          isSelected(dateIndex, topMeetingIdx)
-                        }
+                        slotIndex={group.botSlotIdx}
+                        isSelected={isSelected(dateIndex, group.botSlotIdx)}
                         height={SLOT_H}
-                        disabled={topMeetingIdx === null}
                       />
-                      <div
-                        className='border-t border-dashed border-white/40'
-                        style={{ marginTop: -1 }}
-                      />
-                      <TimeSlotCell
-                        dateIndex={dateIndex}
-                        slotIndex={botMeetingIdx ?? -1}
-                        isSelected={
-                          botMeetingIdx !== null &&
-                          isSelected(dateIndex, botMeetingIdx)
-                        }
-                        height={SLOT_H}
-                        disabled={botMeetingIdx === null}
-                      />
-                    </div>
-                  );
-                })}
+                    ) : (
+                      <div style={{ height: SLOT_H }} />
+                    )}
+                  </div>
+                ))}
               </div>
             </div>
           );

--- a/src/features/vote-rank-cards/lib/mock.ts
+++ b/src/features/vote-rank-cards/lib/mock.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated [#73, 2026-05-07] 본 파일의 mock fixtures는 운영 라우트(`/meet/[meetingId]`)가 실 API 어댑터(`toMeetingVoteSnapshot`)로 전환되며 운영 사용처 0개.
+ * 현재 사용처: `/test/vote-rank-cards`(개발용 라우트), Storybook stories.
+ * Removal target: test 라우트와 함께 별도 정리 PR (specs/feat/073-vote-rank-cards-api/plan.md TODO-9 참조).
+ */
 import type {
   MeetingVoteSnapshot,
   ParticipantVote,

--- a/src/features/vote-rank-cards/ui/VoteRankCardsPage.tsx
+++ b/src/features/vote-rank-cards/ui/VoteRankCardsPage.tsx
@@ -1,3 +1,8 @@
+/**
+ * @deprecated [#73, 2026-05-07] 운영 결과 페이지는 `MeetResultTablePage`(meet-result-table feature) 가 토글로 표/카드 뷰를 모두 처리. 본 standalone 페이지는 `/test/vote-rank-cards` 만 사용.
+ * Replacement: `MeetResultTablePage`
+ * Removal target: test 라우트와 함께 별도 정리 PR.
+ */
 'use client';
 
 import { useMemo } from 'react';

--- a/src/shared/ui/Badge.tsx
+++ b/src/shared/ui/Badge.tsx
@@ -11,9 +11,12 @@ const badgeVariants = cva(
         default:
           'border-transparent bg-primary-default text-text-inverse hover:bg-primary-subtle',
         secondary: 'border-transparent bg-gray-100 text-gray-900',
-        rank1: 'border-transparent bg-primary-default text-gray-0',
-        rank2: 'border-transparent bg-primary-subtle text-gray-0',
-        rank3: 'border-transparent bg-primary-subtle text-gray-0',
+        // 2026-04-29 이전 라이브 (moit.kr) 색상 복원: outline 스타일.
+        // ReactDatepicker (vote-results-calendar) 의 캘린더 셀 뱃지가 라이브와 일치해야 함.
+        rank1: 'border-primary-default bg-gray-0 text-primary-default',
+        rank2: 'border-primary-default bg-gray-0 text-primary-default',
+        rank3: 'border-primary-default bg-gray-0 text-primary-default',
+        // @deprecated [#73] PR #72에서 추가됐으나 사용처 0. RankChip 자체 매핑이 있어 Badge 의존 없음. Removal: TODO-9.
         rank4: 'border-transparent bg-gray-300 text-gray-700',
         rank5: 'border-transparent bg-gray-300 text-gray-700',
         outline: 'text-text-primary',


### PR DESCRIPTION
# 🚩 연관 이슈

closed #73

# 📝 작업 내용

vote-rank-cards 결과 페이지의 실 API 연동 + 참여자 시간 슬롯 투표 입력 UI 신규 + PR #72 follow-up 정리를 한 단위로 담습니다.

## 1. 결과 페이지 실 API 연동 (`/meet/[meetingId]`)

- mock 시드 기반 `buildMockSnapshot` / `generateMockVoteTimeSlotStat` 호출 종료
- 신규 어댑터 3종으로 raw 응답을 ViewModel/집계 형태로 변환
  - `entities/meet/lib/toMeetingVoteSnapshot` — `MeetResponse` → `MeetingVoteSnapshot`
  - `entities/voteTimeSlotStat/lib/buildVoteTimeSlotStat` — 시간대 셀 집계 (히트맵 입력)
  - `entities/voteDateStat/lib/buildVoteDateStat` — 날짜 단위 집계 (캘린더 입력)
- `meetResponseDto` zod 스키마 확장: `participantDto.voteTimeSlots`, `meetResponseDto.{status, finalizedDate, timeRange}`
- 서버 LocalTime 직렬화 형태(`HH:mm:ss` / `H:mm`) 를 `HH:mm` 으로 정규화
- `timeRange` 유무로 분기:
  - 시간 모임 → 표/카드 토글 (PR #71/#72 결합 사용)
  - 날짜 모임 → 4-29 이전 캘린더 화면 형태 복원 (`Header` + `VoteResultDataView`, `bg-gray-50`)
- 진입 시 ky `HTTPError` 404 만 `notFound()` 처리, 그 외 5xx/zod validation 실패는 `error.tsx` 에 위임
- `loading.tsx` (인-페이지 스켈레톤) + `error.tsx` (다시 시도 CTA) 신규

## 2. 참여자 시간 슬롯 투표 입력 UI 신규 (`participant-register-time-slot`)

- `register/date` / `edit/date` 라우트가 `timeRange` 유무로 분기
  - 시간 모임 → 시간 슬롯 그리드 (드래그 다중 선택)
  - 날짜 모임 → 기존 캘린더 입력 (변경 없음)
- PR #71의 `HeatmapGrid` 와 동일한 layout/색/크기 (sticky 시간 컬럼·날짜 헤더, 1시간 그룹 `rounded-[10px]`, 4.5컬럼 가시성). 입력 BASE 톤은 `bg-[#F1F5FB]` 로 시안 매칭
- 드래그 인터랙션: 시작 셀이 unselected → additive(추가) 모드, selected → remove(해제) 모드. 시작·끝점 사각형 영역에 모드 적용
- 수정 모드는 본인 기존 투표(`voteTimeSlots`) 를 grid 에 미리 채워서 시작
- "모든 날짜에 참여가 어려워요" 체크박스로 전체 unset
- `voteRequestDto` 에 `voteTimeSlots: optional` 추가 (`voteMeeting` POST / `updateVote` PUT 둘 다 자동 반영)

## 3. PR #72 follow-up 정리

- **CellInfoCard 시안 매칭**: 셀 클릭 모달을 [Figma 시안](https://www.figma.com/design/3QGpLOWvN7ZvBpYhqqzcJ4/moit-UI-Design?node-id=3754-5517) 기준으로 단순화. 드래그/스냅/수납 인터랙션 제거, ✓/✕ 유니코드 → `Icon` 컴포넌트(`ic_circle_check_filled`, `ic_circle_x_filled`), 빈 상태 문구 통일 (`아무도 없어요` / `모두 가능해요`). 따라서 `useSelectedCell` / `ResultTableView` / `MeetResultTablePage` 의 `isExpanded·position·collapse·expand·moveTo` props 제거.
- **HeatmapCell ring 강조 제거**: 시안에 없는 시각 강조였음. `aria-selected` 는 유지 (접근성).
- **Badge variants `rank1/2/3` 색 복원**: PR #72 에서 outline → fill 톤으로 바꾼 것을 4-29 이전 라이브 색상으로 되돌림. `ReactDatepicker` 의 캘린더 셀 뱃지가 라이브와 일치.
- **Deprecation 주석** (사용자 명시 제약: "지금 지우지 말고 주석처리"): 운영 호출 0이 된 헬퍼들에 표준 `@deprecated` 주석을 부여하고 코드는 보존 (`vote-rank-cards/lib/mock`, `VoteRankCardsPage`, `app/test/vote-rank-cards`, `fetchVoteTimeSlotStat`, `voteTimeSlotStat/lib/mock`, `fetchVoteDateStat`, `app/meet/[meetingId]/page.tsx` 의 `buildMockSnapshot`). 실제 파일·심볼 제거는 별도 정리 PR(plan.md TODO-9).

## 4. 단위 테스트

신규 어댑터 3종에 대한 vitest 케이스 18개 + 기존 vitest 95개 통과. data-model.md §7 매트릭스 충족.

# ⚠️ 의도적 lint warning 3건 (deprecation 정책)

`@deprecated` 주석으로 보존된 헬퍼들이 운영 코드에서 호출 0인 상태라 다음 warning 이 발생합니다 (의도된 결과):

- `page.tsx` `buildMockSnapshot is defined but never used`
- `fetchVoteTimeSlotStat` `_params is defined but never used`
- `fetchVoteDateStat` `_params is defined but never used`

본 PR 이 새로 추가한 lint warning 은 0건입니다.

# 📋 Carry-over TODO (별도 PR 예정)

- **TODO-7**: `meet-result-table` → `vote-rank-cards` 의 feature → feature import (FSD 위반) 해소 — widgets 추출 또는 타입 이전
- **TODO-8**: `MeetingVoteSnapshot` 타입을 `entities/meet/dto/`로 이전
- **TODO-9**: 본 PR 의 deprecation 9건 일괄 제거

자세한 내용은 [`specs/feat/073-vote-rank-cards-api/plan.md`](specs/feat/073-vote-rank-cards-api/plan.md) 의 TODO 섹션 참조.

# 🗣️ 리뷰 요구사항 (선택)

- **시각 회귀 우선 확인**: 결과 페이지 (시간 모임 / 날짜 모임 둘 다), 시간 슬롯 입력 그리드 (시안 비교), 캘린더 뱃지 색
- **데이터 매핑 검증**: dates 와 voteTimeSlots row 의 인덱스는 server 응답 순서를 그대로 신뢰합니다. 만약 server 가 비정렬 응답하는 케이스가 있다면 알려주세요.