### PR TITLE
feat/#78 time-vote-spacing-fix 시간 투표하기 마진 변경

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,9 @@ Auto-generated from all feature plans. Last updated: 2026-02-14
 
 ## Active Technologies
 
+- TypeScript 5 + Next.js 16 (App Router), React 19, Tailwind CSS 4 + CVA + clsx + tailwind-merge (feat/#78-time-vote-spacing-fix)
+- N/A (클라이언트 상태만) (feat/#78-time-vote-spacing-fix)
+
 - TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul (바텀 시트 후보), date-fns ^4.1.0 (feat/#131-time-range-picker)
 - TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul(바텀 시트 — `@/shared/ui/bottom-sheet/BottomSheet`에서 캡슐화), date-fns ^4.1.0, react-datepicker ^9.1.0(기존), ky(HTTP), zod(검증), Amplitude(analytics) (feat/#131-time-range-picker)
 - N/A — 클라이언트 상태만. 서버 저장은 `POST /v1/meeting` 바디에 직렬화된 `timeRange`로 단발 전송. (feat/#131-time-range-picker)
@@ -35,13 +38,10 @@ TypeScript 5: Follow standard conventions
 
 ## Recent Changes
 
+- feat/#78-time-vote-spacing-fix: Added TypeScript 5 + Next.js 16 (App Router), React 19, Tailwind CSS 4 + CVA + clsx + tailwind-merge
+
 - feat/#131-time-range-picker: Added TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul(바텀 시트 — `@/shared/ui/bottom-sheet/BottomSheet`에서 캡슐화), date-fns ^4.1.0, react-datepicker ^9.1.0(기존), ky(HTTP), zod(검증), Amplitude(analytics)
 - feat/#131-time-range-picker: Added TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul (바텀 시트 후보), date-fns ^4.1.0
-
-- feat/#68-vote-rank-cards: Added TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, date-fns, ky(미사용 — 본 단계 mock), zod(미사용 — 본 단계 mock)
-- feat/#68-vote-rank-cards: Added N/A (클라이언트 mock fixture)
-
-- feat/#127-calendar-drag-path: Added TypeScript 5 + React 19, Next.js 16 (App Router), react-datepicker ^9.1.0, date-fns ^4.1.0
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/src/features/meet-create-date/ui/DateSelectPage.tsx
+++ b/src/features/meet-create-date/ui/DateSelectPage.tsx
@@ -88,7 +88,7 @@ export default function DateSelectPage({
         </h1>
 
         {/* 캘린더 영역 */}
-        <div className='mb-6 flex justify-center'>
+        <div className='flex justify-center'>
           <ReactDatepickerAdapter
             selectedDates={selectedDates}
             onChange={handleDateChangeWithTracking}

--- a/src/features/time-range-select/ui/TimeRangePicker.tsx
+++ b/src/features/time-range-select/ui/TimeRangePicker.tsx
@@ -24,10 +24,6 @@ interface TimeRangePickerProps {
   ) => void;
 }
 
-function displayTime(t: TimeValue): string {
-  return `${String(t.hour).padStart(2, '0')} : ${String(t.minute).padStart(2, '0')}`;
-}
-
 /** minTime 이후의 첫 번째 유효 시각을 반환 */
 function firstValidAfter(minTime: TimeValue): TimeValue {
   if (minTime.minute === 0) return { hour: minTime.hour, minute: 30 };
@@ -120,10 +116,10 @@ export default function TimeRangePicker({
 
   return (
     <>
-      <section className='px-5 py-4'>
+      <section className='flex flex-col gap-2.5'>
         {/* 섹션 헤더 + 토글 */}
-        <div className='flex items-center justify-between'>
-          <span className='text-text-primary text-lg font-bold'>
+        <div className='flex items-center justify-between pt-6 pb-2'>
+          <span className='text-text-secondary text-lg font-semibold'>
             시간 투표 받기
           </span>
           <Toggle
@@ -134,37 +130,60 @@ export default function TimeRangePicker({
         </div>
 
         {isEnabled && (
-          <div className='mt-4 flex flex-col gap-3'>
+          <div className='flex flex-col gap-2.5'>
             {/* 시작 시간 카드 */}
             <button
               type='button'
               onClick={() => openPicker('start')}
-              className='flex w-full items-center justify-between rounded-2xl border border-gray-200 px-5 py-4'
+              className='flex w-full items-center gap-5'
             >
-              <span className='text-text-primary text-base font-medium'>
+              <span className='text-text-secondary shrink-0 text-base font-medium'>
                 시작 시간
               </span>
-              <span className='text-text-primary text-base font-semibold tabular-nums'>
-                {displayTime(startTime ?? DEFAULT_START_TIME)}
-              </span>
+              <div className='text-text-secondary flex flex-1 items-center justify-between rounded-[6px] border border-gray-200 bg-white px-5 py-3.5'>
+                <span className='min-w-0 flex-1 text-center text-lg font-semibold tabular-nums'>
+                  {String((startTime ?? DEFAULT_START_TIME).hour).padStart(
+                    2,
+                    '0',
+                  )}
+                </span>
+                <span className='shrink-0 text-lg font-semibold'>:</span>
+                <span className='min-w-0 flex-1 text-center text-lg font-semibold tabular-nums'>
+                  {String((startTime ?? DEFAULT_START_TIME).minute).padStart(
+                    2,
+                    '0',
+                  )}
+                </span>
+              </div>
             </button>
 
             {/* 종료 시간 카드 */}
             <button
               type='button'
               onClick={() => openPicker('end')}
-              className='flex w-full items-center justify-between rounded-2xl border border-gray-200 px-5 py-4'
+              className='flex w-full items-center gap-5'
             >
-              <span className='text-text-primary text-base font-medium'>
+              <span className='text-text-secondary shrink-0 text-base font-medium'>
                 종료 시간
               </span>
-              <span
-                className={`text-base font-semibold tabular-nums ${
-                  isEndInvalid ? 'text-red-400' : 'text-text-primary'
+              <div
+                className={`flex flex-1 items-center justify-between rounded-[6px] border bg-white px-5 py-3.5 ${
+                  isEndInvalid
+                    ? 'border-red-400 text-red-400'
+                    : 'text-text-secondary border-gray-200'
                 }`}
               >
-                {displayTime(endTime ?? DEFAULT_END_TIME)}
-              </span>
+                <span className='min-w-0 flex-1 text-center text-lg font-semibold tabular-nums'>
+                  {String((endTime ?? DEFAULT_END_TIME).hour).padStart(2, '0')}
+                </span>
+                <span className='shrink-0 text-lg font-semibold'>:</span>
+                <span className='min-w-0 flex-1 text-center text-lg font-semibold tabular-nums'>
+                  {String((endTime ?? DEFAULT_END_TIME).minute).padStart(
+                    2,
+                    '0',
+                  )}
+                </span>
+              </div>
             </button>
           </div>
         )}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #78

# 📝 작업 내용

- `TimeRangePicker`: 시간 투표 UI 레이아웃을 피그마 시안에 맞게 수정
  - 섹션 패딩(`px-5 py-4`) → `flex flex-col gap-2.5` 구조로 변경
  - 헤더 영역 상하 패딩 분리(`pt-6 pb-2`) 및 텍스트 스타일 조정 (`text-text-secondary`, `font-semibold`)
  - 시작/종료 시간 카드: 테두리 박스 형태로 시·분을 분리 표시하도록 UI 개선
  - `displayTime` 헬퍼 함수 제거 후 시·분 각각 인라인 렌더링으로 교체
- `DateSelectPage`: 캘린더 영역 하단 여백(`mb-6`) 제거

# 🗣️ 리뷰 요구사항 (선택)