### PR TITLE
feat/#80-weekend-day-color 토요일과 일요일 색상 분리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,13 +35,10 @@ TypeScript 5: Follow standard conventions
 
 ## Recent Changes
 
+- feat/#80-weekend-day-color: Added [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
+
 - feat/#131-time-range-picker: Added TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul(바텀 시트 — `@/shared/ui/bottom-sheet/BottomSheet`에서 캡슐화), date-fns ^4.1.0, react-datepicker ^9.1.0(기존), ky(HTTP), zod(검증), Amplitude(analytics)
 - feat/#131-time-range-picker: Added TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul (바텀 시트 후보), date-fns ^4.1.0
-
-- feat/#68-vote-rank-cards: Added TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, date-fns, ky(미사용 — 본 단계 mock), zod(미사용 — 본 단계 mock)
-- feat/#68-vote-rank-cards: Added N/A (클라이언트 mock fixture)
-
-- feat/#127-calendar-drag-path: Added TypeScript 5 + React 19, Next.js 16 (App Router), react-datepicker ^9.1.0, date-fns ^4.1.0
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/src/features/meet-result-table/ui/HeatmapGrid.tsx
+++ b/src/features/meet-result-table/ui/HeatmapGrid.tsx
@@ -133,7 +133,8 @@ export default function HeatmapGrid({
         {slotStat.dates.map((date, dateIndex) => {
           const { weekday, md } = formatDateHeader(date);
           const dow = parseDate(date).getDay();
-          const isWeekend = dow === 0 || dow === 6;
+          const isSunday = dow === 0;
+          const isSaturday = dow === 6;
           const prevDate = dateIndex > 0 ? slotStat.dates[dateIndex - 1] : null;
           const isWeekChange =
             prevDate !== null &&
@@ -157,7 +158,11 @@ export default function HeatmapGrid({
               >
                 <span
                   className={`text-[12px] font-semibold ${
-                    isWeekend ? 'text-red-400' : 'text-text-tertiary'
+                    isSunday
+                      ? 'text-red-400'
+                      : isSaturday
+                        ? 'text-blue-60'
+                        : 'text-text-tertiary'
                   }`}
                 >
                   {weekday}

--- a/src/features/participant-register-time-slot/ui/TimeSlotGrid.tsx
+++ b/src/features/participant-register-time-slot/ui/TimeSlotGrid.tsx
@@ -190,7 +190,8 @@ export default function TimeSlotGrid({
         {dates.map((date, dateIndex) => {
           const { weekday, md } = formatDateHeader(date);
           const dow = parseDate(date).getDay();
-          const isWeekend = dow === 0 || dow === 6;
+          const isSunday = dow === 0;
+          const isSaturday = dow === 6;
           const prevDate = dateIndex > 0 ? dates[dateIndex - 1] : null;
           const isWeekChange =
             prevDate !== null &&
@@ -214,7 +215,11 @@ export default function TimeSlotGrid({
               >
                 <span
                   className={`text-[12px] font-semibold ${
-                    isWeekend ? 'text-red-400' : 'text-text-tertiary'
+                    isSunday
+                      ? 'text-red-400'
+                      : isSaturday
+                        ? 'text-blue-60'
+                        : 'text-text-tertiary'
                   }`}
                 >
                   {weekday}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #80

# 📝 작업 내용
<img width="696" height="926" alt="image" src="https://github.com/user-attachments/assets/53859c0b-45da-4673-a359-505647f00403" />

- `TimeSlotGrid.tsx`, `HeatmapGrid.tsx`의 요일 헤더 색상 로직 수정
  - 기존: `isWeekend` 단일 플래그로 토·일 모두 `text-red-400` 적용
  - 변경: `isSunday`(dow===0) / `isSaturday`(dow===6) 분리
    - 일요일 → `text-red-400` (빨간색)
    - 토요일 → `text-blue-60` (파란색, `@theme` 커스텀 토큰)
    - 평일 → `text-text-tertiary`
- 투표 입력, 투표 수정, 투표 결과 세 화면 모두 동일하게 반영

# 🗣️ 리뷰 요구사항 (선택)