### PR TITLE
feat/#82-keyboard-next-focus keyboard-next-focus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-14
 
 ## Active Technologies
 
+- N/A (클라이언트 상태만) (feat/#82-keyboard-next-focus)
+
 - TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul (바텀 시트 후보), date-fns ^4.1.0 (feat/#131-time-range-picker)
 - TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul(바텀 시트 — `@/shared/ui/bottom-sheet/BottomSheet`에서 캡슐화), date-fns ^4.1.0, react-datepicker ^9.1.0(기존), ky(HTTP), zod(검증), Amplitude(analytics) (feat/#131-time-range-picker)
 - N/A — 클라이언트 상태만. 서버 저장은 `POST /v1/meeting` 바디에 직렬화된 `timeRange`로 단발 전송. (feat/#131-time-range-picker)
@@ -35,13 +37,10 @@ TypeScript 5: Follow standard conventions
 
 ## Recent Changes
 
+- feat/#82-keyboard-next-focus: Added TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4
+
 - feat/#131-time-range-picker: Added TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul(바텀 시트 — `@/shared/ui/bottom-sheet/BottomSheet`에서 캡슐화), date-fns ^4.1.0, react-datepicker ^9.1.0(기존), ky(HTTP), zod(검증), Amplitude(analytics)
 - feat/#131-time-range-picker: Added TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, vaul (바텀 시트 후보), date-fns ^4.1.0
-
-- feat/#68-vote-rank-cards: Added TypeScript 5 + React 19, Next.js 16 (App Router), Tailwind CSS 4 + CVA + clsx + tailwind-merge, date-fns, ky(미사용 — 본 단계 mock), zod(미사용 — 본 단계 mock)
-- feat/#68-vote-rank-cards: Added N/A (클라이언트 mock fixture)
-
-- feat/#127-calendar-drag-path: Added TypeScript 5 + React 19, Next.js 16 (App Router), react-datepicker ^9.1.0, date-fns ^4.1.0
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from 'next';
+import path from 'path';
 
 const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
 
@@ -11,6 +12,9 @@ if (!apiBaseUrl) {
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
+  turbopack: {
+    root: path.resolve(__dirname),
+  },
   async rewrites() {
     return [
       {

--- a/src/features/meet-create/ui/MeetCreatePage.tsx
+++ b/src/features/meet-create/ui/MeetCreatePage.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useRef } from 'react';
 
 import { trackEvent } from '@/shared/lib/amplitude';
+import { handleKeyboardNav } from '@/shared/lib/handleKeyboardNav';
 import Button from '@/shared/ui/button/Button';
 import Input from '@/shared/ui/input/Input';
 import TopBar from '@/shared/ui/top-bar/TopBar';
@@ -20,6 +22,8 @@ export default function MeetCreatePage({
   initialMeetingName = '',
 }: MeetCreatePageProps) {
   const router = useRouter();
+  const meetingNameInputRef = useRef<HTMLInputElement>(null);
+
   const {
     hostName,
     meetingName,
@@ -98,8 +102,10 @@ export default function MeetCreatePage({
             onChange={handleHostNameChange}
             onBlur={handleHostNameBlur}
             onClear={handleHostNameClear}
+            onKeyDown={(e) => handleKeyboardNav(e, meetingNameInputRef)}
             placeholder='이름을 입력해주세요'
             maxLength={10}
+            enterKeyHint='next'
             fullWidth
             required
             autoFocus
@@ -107,13 +113,16 @@ export default function MeetCreatePage({
           />
 
           <Input
+            ref={meetingNameInputRef}
             label='모임명'
             value={meetingName}
             onChange={handleMeetingNameChange}
             onBlur={handleMeetingNameBlur}
             onClear={handleMeetingNameClear}
+            onKeyDown={(e) => handleKeyboardNav(e)}
             placeholder={meetingNamePlaceholder}
             maxLength={10}
+            enterKeyHint='done'
             fullWidth
             errorMessage={meetingNameError}
             suppressHydrationWarning

--- a/src/features/participant-edit-name/ui/ParticipantEditNamePage.tsx
+++ b/src/features/participant-edit-name/ui/ParticipantEditNamePage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { trackEvent } from '@/shared/lib/amplitude';
+import { handleKeyboardNav } from '@/shared/lib/handleKeyboardNav';
 import Button from '@/shared/ui/button/Button';
 import { Header } from '@/shared/ui/header/Header';
 import Input from '@/shared/ui/input/Input';
@@ -59,8 +60,10 @@ export default function ParticipantEditNamePage({
             onChange={handleNameChange}
             onBlur={handleNameBlur}
             onClear={handleNameClear}
+            onKeyDown={(e) => handleKeyboardNav(e)}
             placeholder='투표에 참여했던 이름을 입력해주세요'
             maxLength={maxLength}
+            enterKeyHint='done'
             fullWidth
             required
             autoFocus // 화면 진입 시 자동 포커스

--- a/src/features/participant-register-name/ui/ParticipantRegisterNamePage.tsx
+++ b/src/features/participant-register-name/ui/ParticipantRegisterNamePage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { trackEvent } from '@/shared/lib/amplitude';
+import { handleKeyboardNav } from '@/shared/lib/handleKeyboardNav';
 import Button from '@/shared/ui/button/Button';
 import { Header } from '@/shared/ui/header/Header';
 import Input from '@/shared/ui/input/Input';
@@ -52,8 +53,10 @@ export default function ParticipantRegisterNamePage({
             onChange={handleNameChange}
             onBlur={handleNameBlur}
             onClear={handleNameClear}
+            onKeyDown={(e) => handleKeyboardNav(e)}
             placeholder='이름을 입력해주세요'
             maxLength={maxLength}
+            enterKeyHint='done'
             fullWidth
             required
             autoFocus // 화면 진입 시 자동 포커스

--- a/src/shared/lib/handleKeyboardNav.ts
+++ b/src/shared/lib/handleKeyboardNav.ts
@@ -1,0 +1,13 @@
+import type { KeyboardEvent, RefObject } from 'react';
+
+export function handleKeyboardNav(
+  e: KeyboardEvent<HTMLInputElement>,
+  nextRef?: RefObject<HTMLInputElement | null>,
+) {
+  if (e.key !== 'Enter') return;
+  if (nextRef?.current) {
+    nextRef.current.focus();
+  } else {
+    (e.currentTarget as HTMLInputElement).blur();
+  }
+}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #82

# 📝 작업 내용

- `handleKeyboardNav` 유틸 함수 추가 (`src/shared/lib/handleKeyboardNav.ts`)
  - `Enter` 키 입력 시 `nextRef`가 있으면 다음 input으로 포커스 이동, 없으면 키보드 닫힘(blur)
- 모임 생성 페이지(`MeetCreatePage`) 키보드 네비게이션 적용
  - 호스트 이름 input: `enterKeyHint="next"`, 모임명 input으로 포커스 이동
  - 모임명 input: `enterKeyHint="done"`, 키보드 닫힘
- 참여자 이름 등록 페이지(`ParticipantRegisterNamePage`) 키보드 네비게이션 적용
  - 단일 input: `enterKeyHint="done"`, 키보드 닫힘
- 참여자 이름 수정 페이지(`ParticipantEditNamePage`) 키보드 네비게이션 적용
  - 단일 input: `enterKeyHint="done"`, 키보드 닫힘
- `next.config.ts` turbopack root 경로 설정 추가

# 🗣️ 리뷰 요구사항 (선택)