### PR TITLE
fix/#84-time-slot-tap-tap 시간 슬롯 그리드 인터랙션 탭-탭 전환 + Figma 시안 매칭

### DIFF
--- a/src/features/meet-result-table/lib/timeSlotConstants.ts
+++ b/src/features/meet-result-table/lib/timeSlotConstants.ts
@@ -10,7 +10,9 @@ export const OPACITY_CLASS_MAP: Record<OpacityLevel, string> = {
   10: 'bg-[#3C7EFA]/10',
 };
 
-export const BASE_TONE_CLASS = 'bg-[#3C7EFA]/[0.04]';
+// 시안 (Figma 3617:5634 / 3770:6061) 기준: BASE 셀 = #F9FAFB (Tailwind gray-50).
+// 모든 셀의 점선 분리는 #E6E8EB (≈ gray-200) 회색, 셀 색과 무관하게 동일 색으로 BASE/selected 양쪽 모두에서 보이도록 한다.
+export const BASE_TONE_CLASS = 'bg-gray-50';
 
 export function rankFromOpacity(opacity: OpacityLevel | null): number | null {
   if (opacity === null) return null;

--- a/src/features/meet-result-table/ui/HeatmapGrid.stories.tsx
+++ b/src/features/meet-result-table/ui/HeatmapGrid.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { generateMockVoteTimeSlotStat } from '@/entities/voteTimeSlotStat/lib/mock';
+
+import HeatmapGrid from './HeatmapGrid';
+
+const meta: Meta<typeof HeatmapGrid> = {
+  title: 'Features/MeetResultTable/HeatmapGrid',
+  component: HeatmapGrid,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  args: {
+    selected: null,
+    onSelect: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof HeatmapGrid>;
+
+const PARTICIPANTS = Array.from({ length: 9 }, (_, i) => ({
+  id: i + 1,
+  name: `참여자${i + 1}`,
+}));
+
+const FOUR_DATES = ['2026-04-16', '2026-04-17', '2026-04-18', '2026-04-20'];
+const SEVEN_DATES = [...FOUR_DATES, '2026-04-21', '2026-04-22', '2026-04-23'];
+const ONE_DATE = ['2026-04-16'];
+const MANY_DATES = Array.from({ length: 14 }, (_, i) => {
+  const d = new Date('2026-04-16');
+  d.setDate(d.getDate() + i);
+  return d.toISOString().slice(0, 10);
+});
+
+export const FullVote: Story = {
+  name: '풀 투표 (9명, 7일) — Figma 기본',
+  args: {
+    slotStat: generateMockVoteTimeSlotStat('demo-1', SEVEN_DATES),
+  },
+};
+
+export const FewDates: Story = {
+  name: '후보 날짜 1개',
+  args: {
+    slotStat: generateMockVoteTimeSlotStat('demo-2', ONE_DATE),
+  },
+};
+
+export const FourDates: Story = {
+  name: '후보 날짜 4개 — 화면 폭 딱 맞음',
+  args: {
+    slotStat: generateMockVoteTimeSlotStat('demo-3', FOUR_DATES),
+  },
+};
+
+export const ManyDates: Story = {
+  name: '후보 날짜 14개 — 가로 스크롤',
+  args: {
+    slotStat: generateMockVoteTimeSlotStat('demo-4', MANY_DATES),
+  },
+};
+
+export const ZeroVotes: Story = {
+  name: '0명 투표 — 모든 셀 베이스 톤',
+  args: {
+    slotStat: {
+      meetingId: 'empty',
+      dates: SEVEN_DATES,
+      cells: SEVEN_DATES.flatMap((date) =>
+        Array.from({ length: 24 }, (_, slotIdx) => ({
+          date,
+          slotIdx,
+          count: 0,
+          participants: [],
+        })),
+      ),
+      allParticipants: PARTICIPANTS,
+    },
+  },
+};
+
+export const AllTied: Story = {
+  name: '모든 셀 동률 5명 — 1위 100% 단일 농도',
+  args: {
+    slotStat: {
+      meetingId: 'tied',
+      dates: FOUR_DATES,
+      cells: FOUR_DATES.flatMap((date) =>
+        Array.from({ length: 24 }, (_, slotIdx) => ({
+          date,
+          slotIdx,
+          count: 5,
+          participants: PARTICIPANTS.slice(0, 5),
+        })),
+      ),
+      allParticipants: PARTICIPANTS,
+    },
+  },
+};

--- a/src/features/meet-result-table/ui/HeatmapGrid.tsx
+++ b/src/features/meet-result-table/ui/HeatmapGrid.tsx
@@ -116,16 +116,22 @@ export default function HeatmapGrid({
       >
         <div style={{ height: DAY_HEADER_H }} />
         <div className='flex flex-col' style={{ gap: ROW_GAP }}>
-          {groups.map((group) => (
-            <div
-              key={group.hour}
-              role='rowheader'
-              style={{ height: HOUR_H }}
-              className='text-text-tertiary flex items-start justify-end pr-2 text-[14px] leading-5 font-medium'
-            >
-              {group.hour}
-            </div>
-          ))}
+          {groups.map((group) => {
+            const visibleSlots =
+              (group.topSlotIdx !== null ? 1 : 0) +
+              (group.botSlotIdx !== null ? 1 : 0);
+            const rowHeight = visibleSlots === 1 ? SLOT_H : HOUR_H;
+            return (
+              <div
+                key={group.hour}
+                role='rowheader'
+                style={{ height: rowHeight }}
+                className='text-text-tertiary flex items-start justify-end pr-2 text-[14px] leading-5 font-medium'
+              >
+                {group.hour}
+              </div>
+            );
+          })}
         </div>
       </div>
 
@@ -176,10 +182,13 @@ export default function HeatmapGrid({
                 {groups.map((group) => {
                   const topSlotIdx = group.topSlotIdx;
                   const botSlotIdx = group.botSlotIdx;
-                  const topKey =
-                    topSlotIdx !== null ? cellKey(date, topSlotIdx) : null;
-                  const botKey =
-                    botSlotIdx !== null ? cellKey(date, botSlotIdx) : null;
+                  const hasTop = topSlotIdx !== null;
+                  const hasBot = botSlotIdx !== null;
+                  const visibleSlots = (hasTop ? 1 : 0) + (hasBot ? 1 : 0);
+                  const rowHeight = visibleSlots === 1 ? SLOT_H : HOUR_H;
+
+                  const topKey = hasTop ? cellKey(date, topSlotIdx) : null;
+                  const botKey = hasBot ? cellKey(date, botSlotIdx) : null;
                   const topCell = topKey ? cellByKey.get(topKey) : undefined;
                   const botCell = botKey ? cellByKey.get(botKey) : undefined;
                   const topIntensity =
@@ -191,10 +200,10 @@ export default function HeatmapGrid({
                     <div
                       key={`${date}-${group.hour}`}
                       role='row'
-                      className='overflow-hidden rounded-[10px]'
-                      style={{ height: HOUR_H }}
+                      className='rounded-dropdown relative flex flex-col overflow-hidden'
+                      style={{ height: rowHeight }}
                     >
-                      {topSlotIdx !== null ? (
+                      {hasTop && (
                         <HeatmapCell
                           date={date}
                           slotIdx={topSlotIdx}
@@ -207,17 +216,8 @@ export default function HeatmapGrid({
                             selected?.slotIdx === topSlotIdx
                           }
                         />
-                      ) : (
-                        <div style={{ height: SLOT_H }} />
                       )}
-                      <div
-                        className='border-t border-dashed border-white/40'
-                        style={{
-                          marginTop: -1,
-                          opacity: botIntensity !== null ? 1 : 0,
-                        }}
-                      />
-                      {botSlotIdx !== null ? (
+                      {hasBot && (
                         <HeatmapCell
                           date={date}
                           slotIdx={botSlotIdx}
@@ -230,8 +230,18 @@ export default function HeatmapGrid({
                             selected?.slotIdx === botSlotIdx
                           }
                         />
-                      ) : (
-                        <div style={{ height: SLOT_H }} />
+                      )}
+                      {hasTop && hasBot && (
+                        // absolute 로 띄워 flow 영향 0. 두 셀 사이 정확히 가운데에 점선.
+                        // 점선 색은 시안 #E6E8EB (≈ border-gray-200) — 셀 색(BASE/intensity) 무관 항상 회색.
+                        <div
+                          aria-hidden
+                          className='pointer-events-none absolute right-0 left-0 border-t border-dashed border-gray-200'
+                          style={{
+                            top: SLOT_H,
+                            opacity: botIntensity !== null ? 1 : 0,
+                          }}
+                        />
                       )}
                     </div>
                   );

--- a/src/features/meet-result-table/ui/ResultTableView.stories.tsx
+++ b/src/features/meet-result-table/ui/ResultTableView.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { generateMockVoteTimeSlotStat } from '@/entities/voteTimeSlotStat/lib/mock';
+
+import ResultTableView from './ResultTableView';
+
+const meta: Meta<typeof ResultTableView> = {
+  title: 'Features/MeetResultTable/ResultTableView',
+  component: ResultTableView,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ResultTableView>;
+
+const SEVEN_DATES = [
+  '2026-04-16',
+  '2026-04-17',
+  '2026-04-18',
+  '2026-04-20',
+  '2026-04-21',
+  '2026-04-22',
+  '2026-04-23',
+];
+
+const COMMON = {
+  voteCount: 9,
+  mode: 'table' as const,
+  onToggle: () => {},
+  selected: null,
+  isExpanded: true,
+  position: 'top' as const,
+  onSelect: () => {},
+  onClose: () => {},
+  onCollapse: () => {},
+  onExpand: () => {},
+  onMoveTo: () => {},
+};
+
+export const TableMode: Story = {
+  args: {
+    ...COMMON,
+    slotStat: generateMockVoteTimeSlotStat('demo-table', SEVEN_DATES),
+  },
+};
+
+export const ZeroVotes: Story = {
+  args: {
+    ...COMMON,
+    voteCount: 0,
+    slotStat: {
+      meetingId: 'empty',
+      dates: SEVEN_DATES,
+      cells: [],
+      allParticipants: [],
+    },
+  },
+};

--- a/src/features/participant-register-time-slot/lib/timeSlotMatrix.test.ts
+++ b/src/features/participant-register-time-slot/lib/timeSlotMatrix.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   matrixToSelection,
-  rectKeys,
   selectionToMatrix,
   slotKey,
 } from '@/features/participant-register-time-slot/lib/timeSlotMatrix';
@@ -43,23 +42,5 @@ describe('matrixToSelection', () => {
     expect(set.has('0:1')).toBe(true);
     expect(set.has('1:0')).toBe(true);
     expect(set.size).toBe(2);
-  });
-});
-
-describe('rectKeys', () => {
-  it('단일 셀', () => {
-    expect(rectKeys(1, 2, 1, 2)).toEqual(['1:2']);
-  });
-
-  it('수직 드래그 (같은 날짜, 다른 시간)', () => {
-    expect(rectKeys(0, 1, 0, 3)).toEqual(['0:1', '0:2', '0:3']);
-  });
-
-  it('역방향 드래그도 정렬된 사각형 반환', () => {
-    expect(rectKeys(0, 3, 0, 1)).toEqual(['0:1', '0:2', '0:3']);
-  });
-
-  it('대각선 드래그 (사각형 영역 전체)', () => {
-    expect(rectKeys(0, 0, 1, 1)).toEqual(['0:0', '0:1', '1:0', '1:1']);
   });
 });

--- a/src/features/participant-register-time-slot/lib/timeSlotMatrix.ts
+++ b/src/features/participant-register-time-slot/lib/timeSlotMatrix.ts
@@ -33,26 +33,3 @@ export function matrixToSelection(matrix: boolean[][]): Set<string> {
   }
   return set;
 }
-
-/**
- * 시작 셀 (dateA, slotA) ~ 끝 셀 (dateB, slotB) 사이 직사각형 영역의 키 집합.
- * 같은 dateIndex 컬럼 내에서만 드래그하지만, 안전하게 양방향 처리.
- */
-export function rectKeys(
-  startDate: number,
-  startSlot: number,
-  endDate: number,
-  endSlot: number,
-): string[] {
-  const dMin = Math.min(startDate, endDate);
-  const dMax = Math.max(startDate, endDate);
-  const sMin = Math.min(startSlot, endSlot);
-  const sMax = Math.max(startSlot, endSlot);
-  const keys: string[] = [];
-  for (let d = dMin; d <= dMax; d += 1) {
-    for (let s = sMin; s <= sMax; s += 1) {
-      keys.push(slotKey(d, s));
-    }
-  }
-  return keys;
-}

--- a/src/features/participant-register-time-slot/model/useParticipantEditTimeSlot.ts
+++ b/src/features/participant-register-time-slot/model/useParticipantEditTimeSlot.ts
@@ -25,9 +25,7 @@ interface UseParticipantEditTimeSlotResult {
   isSubmitting: boolean;
   isCtaActive: boolean;
   isSelected: (dateIndex: number, slotIndex: number) => boolean;
-  beginDrag: (dateIndex: number, slotIndex: number) => void;
-  updateDrag: (dateIndex: number, slotIndex: number) => void;
-  endDrag: () => void;
+  onCellTap: (dateIndex: number, slotIndex: number) => void;
   handleAllImpossibleChange: (checked: boolean) => void;
   handleBack: () => void;
   handleSubmit: () => Promise<void>;
@@ -50,15 +48,8 @@ export function useParticipantEditTimeSlot(
   const [isAllImpossible, setIsAllImpossible] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const {
-    selected,
-    isSelected,
-    beginDrag,
-    updateDrag,
-    endDrag,
-    reset,
-    replaceSelection,
-  } = useTimeSlotSelection();
+  const { selected, isSelected, tapCell, reset, replaceSelection } =
+    useTimeSlotSelection();
 
   const successModal = useDisclosure();
 
@@ -156,12 +147,10 @@ export function useParticipantEditTimeSlot(
     isSubmitting,
     isCtaActive,
     isSelected,
-    beginDrag: (d, s) => {
+    onCellTap: (d, s) => {
       if (isAllImpossible) setIsAllImpossible(false);
-      beginDrag(d, s);
+      tapCell(d, s);
     },
-    updateDrag,
-    endDrag,
     handleAllImpossibleChange,
     handleBack,
     handleSubmit,

--- a/src/features/participant-register-time-slot/model/useParticipantRegisterTimeSlot.ts
+++ b/src/features/participant-register-time-slot/model/useParticipantRegisterTimeSlot.ts
@@ -22,9 +22,7 @@ interface UseParticipantRegisterTimeSlotResult {
   isSubmitting: boolean;
   isCtaActive: boolean;
   isSelected: (dateIndex: number, slotIndex: number) => boolean;
-  beginDrag: (dateIndex: number, slotIndex: number) => void;
-  updateDrag: (dateIndex: number, slotIndex: number) => void;
-  endDrag: () => void;
+  onCellTap: (dateIndex: number, slotIndex: number) => void;
   handleAllImpossibleChange: (checked: boolean) => void;
   handleBack: () => void;
   handleSubmit: () => Promise<void>;
@@ -47,8 +45,7 @@ export function useParticipantRegisterTimeSlot(
   const [isAllImpossible, setIsAllImpossible] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { selected, isSelected, beginDrag, updateDrag, endDrag, reset } =
-    useTimeSlotSelection();
+  const { selected, isSelected, tapCell, reset } = useTimeSlotSelection();
 
   const successModal = useDisclosure();
 
@@ -143,12 +140,10 @@ export function useParticipantRegisterTimeSlot(
     isSubmitting,
     isCtaActive,
     isSelected,
-    beginDrag: (d, s) => {
+    onCellTap: (d, s) => {
       if (isAllImpossible) setIsAllImpossible(false);
-      beginDrag(d, s);
+      tapCell(d, s);
     },
-    updateDrag,
-    endDrag,
     handleAllImpossibleChange,
     handleBack,
     handleSubmit,

--- a/src/features/participant-register-time-slot/model/useTimeSlotSelection.ts
+++ b/src/features/participant-register-time-slot/model/useTimeSlotSelection.ts
@@ -2,25 +2,38 @@
 
 import { useCallback, useRef, useState } from 'react';
 
-import {
-  rectKeys,
-  slotKey,
-} from '@/features/participant-register-time-slot/lib/timeSlotMatrix';
+import { slotKey } from '@/features/participant-register-time-slot/lib/timeSlotMatrix';
 
 interface UseTimeSlotSelectionOptions {
   initial?: Set<string>;
 }
 
+type AnchorMode = 'add' | 'remove';
+
+interface Anchor {
+  dateIndex: number;
+  slotIndex: number;
+  mode: AnchorMode;
+}
+
 /**
- * 30분 슬롯 그리드의 드래그 다중 선택 상태 훅.
- * - `beginDrag`: pointer down. 시작 셀이 unselected → additive(추가) 모드, selected → remove(해제) 모드.
- * - `updateDrag`: pointer enter. 시작점 ~ 현재점 사각형 영역에 모드 적용.
- * - `endDrag`: pointer up/cancel/leave. 드래그 종료.
- * - `reset` / `replaceSelection`: 외부에서 selection 일괄 변경 (빈 set / 기존 투표 채움 등).
+ * 30분 슬롯 그리드의 "탭-탭 구간 선택" 상태 훅.
  *
- * 드래그 진행 중 중간 위치(`draggingTo`) 는 외부에 노출하지 않는다 (매 pointermove
- * 시 setState 가 발생하면 그리드 전체가 리렌더되어 성능 저하). 시각 피드백은
- * `selected` set 자체로 충분하다.
+ * 앵커는 위치 + mode(add/remove) 를 같이 들고 있다.
+ *
+ * - 빈 셀 탭: 단일 선택, 앵커 = (위치, add)
+ * - 빈 셀 탭 (같은 컬럼, add 앵커 존재): 앵커 ~ 탭 위치 구간을 모두 선택, 앵커 해제
+ * - 선택된 셀 탭: 단일 해제, 앵커 = (위치, remove)
+ * - 선택된 셀 탭 (같은 컬럼, remove 앵커 존재): 앵커 ~ 탭 위치 구간을 모두 해제, 앵커 해제
+ * - 그 외(컬럼 다름 / mode 불일치): 새 단일 탭으로 재시작 (앵커 갱신)
+ *
+ * 드래그(연속 다중) 는 의도적으로 제공하지 않는다 — 모바일에서 페이지 스크롤과
+ * 충돌하지 않도록 단일 탭만으로 구간을 만들 수 있게 한 결정.
+ *
+ * 구현 메모: `setSelected` 의 업데이터 콜백 안에서 `anchorRef.current` 를 변이하면
+ * React StrictMode 가 업데이터를 두 번 호출하면서 두 번째 실행 시 anchor 가 이미
+ * 변경되어 분기를 잘못 타는 버그가 있다. 그래서 다음 상태 / 다음 앵커는 외부에서
+ * 계산하고 `setSelected` 에는 값만 전달한다.
  */
 export function useTimeSlotSelection(
   options: UseTimeSlotSelectionOptions = {},
@@ -28,64 +41,53 @@ export function useTimeSlotSelection(
   const [selected, setSelected] = useState<Set<string>>(
     () => new Set(options.initial),
   );
-  const dragOriginRef = useRef<{
-    dateIndex: number;
-    slotIndex: number;
-    additive: boolean;
-    baseline: Set<string>;
-  } | null>(null);
+  const anchorRef = useRef<Anchor | null>(null);
 
-  const beginDrag = useCallback(
+  const tapCell = useCallback(
     (dateIndex: number, slotIndex: number) => {
       const key = slotKey(dateIndex, slotIndex);
-      const additive = !selected.has(key);
-      dragOriginRef.current = {
-        dateIndex,
-        slotIndex,
-        additive,
-        baseline: new Set(selected),
-      };
-      setSelected((prev) => {
-        const next = new Set(prev);
-        if (additive) next.add(key);
-        else next.delete(key);
-        return next;
-      });
+      const isAlreadySelected = selected.has(key);
+      const desiredMode: AnchorMode = isAlreadySelected ? 'remove' : 'add';
+
+      const next = new Set(selected);
+      const anchor = anchorRef.current;
+
+      const canRange =
+        anchor !== null &&
+        anchor.dateIndex === dateIndex &&
+        anchor.slotIndex !== slotIndex &&
+        anchor.mode === desiredMode;
+
+      if (canRange && anchor !== null) {
+        const sMin = Math.min(anchor.slotIndex, slotIndex);
+        const sMax = Math.max(anchor.slotIndex, slotIndex);
+        for (let s = sMin; s <= sMax; s += 1) {
+          const k = slotKey(dateIndex, s);
+          if (anchor.mode === 'add') next.add(k);
+          else next.delete(k);
+        }
+        anchorRef.current = null;
+      } else if (isAlreadySelected) {
+        next.delete(key);
+        anchorRef.current = { dateIndex, slotIndex, mode: 'remove' };
+      } else {
+        next.add(key);
+        anchorRef.current = { dateIndex, slotIndex, mode: 'add' };
+      }
+
+      setSelected(next);
     },
     [selected],
   );
 
-  const updateDrag = useCallback((dateIndex: number, slotIndex: number) => {
-    const origin = dragOriginRef.current;
-    if (!origin) return;
-    const region = rectKeys(
-      origin.dateIndex,
-      origin.slotIndex,
-      dateIndex,
-      slotIndex,
-    );
-    setSelected(() => {
-      const next = new Set(origin.baseline);
-      if (origin.additive) {
-        for (const key of region) next.add(key);
-      } else {
-        for (const key of region) next.delete(key);
-      }
-      return next;
-    });
-  }, []);
-
-  const endDrag = useCallback(() => {
-    dragOriginRef.current = null;
-  }, []);
-
   const reset = useCallback(() => {
     setSelected(new Set());
-    dragOriginRef.current = null;
+    anchorRef.current = null;
   }, []);
 
   const replaceSelection = useCallback((next: Set<string>) => {
     setSelected(new Set(next));
+    anchorRef.current = null;
   }, []);
 
   const isSelected = useCallback(
@@ -97,9 +99,7 @@ export function useTimeSlotSelection(
   return {
     selected,
     isSelected,
-    beginDrag,
-    updateDrag,
-    endDrag,
+    tapCell,
     reset,
     replaceSelection,
   };

--- a/src/features/participant-register-time-slot/ui/ParticipantEditTimeSlotPage.tsx
+++ b/src/features/participant-register-time-slot/ui/ParticipantEditTimeSlotPage.tsx
@@ -2,10 +2,9 @@
 
 import { useParticipantEditTimeSlot } from '@/features/participant-register-time-slot/model/useParticipantEditTimeSlot';
 import TimeSlotGrid from '@/features/participant-register-time-slot/ui/TimeSlotGrid';
+import TimeSlotPageFooter from '@/features/participant-register-time-slot/ui/TimeSlotPageFooter';
 import { trackEvent } from '@/shared/lib/amplitude';
 import SuccessBottomSheet from '@/shared/ui/bottom-sheet/SuccessBottomSheet';
-import Button from '@/shared/ui/button/Button';
-import Checkbox from '@/shared/ui/checkbox/Checkbox';
 import { Header } from '@/shared/ui/header/Header';
 import TopBar from '@/shared/ui/top-bar/TopBar';
 
@@ -58,7 +57,7 @@ export default function ParticipantEditTimeSlotPage({
       />
       <Header variant='subHeader' title={'가능한 시간을\n다시 선택해주세요'} />
 
-      <main className='flex flex-1 flex-col pt-1 pb-10'>
+      <main className='flex flex-1 flex-col pt-1 pb-36'>
         <div className='@container relative flex-1'>
           <TimeSlotGrid
             dates={dates}
@@ -67,29 +66,15 @@ export default function ParticipantEditTimeSlotPage({
             onCellTap={onCellTap}
           />
         </div>
-
-        <div className='mt-6 mb-6 px-5'>
-          <div
-            className='flex cursor-pointer items-center gap-2'
-            onClick={() => handleAllImpossibleChange(!isAllImpossible)}
-          >
-            <Checkbox checked={isAllImpossible} onChange={() => {}} />
-            <span className='text-body-4 text-text-secondary select-none'>
-              모든 날짜에 참여가 어려워요
-            </span>
-          </div>
-        </div>
-
-        <div className='px-5'>
-          <Button
-            onClick={handleSubmitWithTracking}
-            disabled={!isCtaActive}
-            fullWidth
-          >
-            수정하기
-          </Button>
-        </div>
       </main>
+
+      <TimeSlotPageFooter
+        isAllImpossible={isAllImpossible}
+        onAllImpossibleChange={handleAllImpossibleChange}
+        ctaLabel='수정하기'
+        isCtaActive={isCtaActive}
+        onCtaClick={handleSubmitWithTracking}
+      />
 
       <SuccessBottomSheet
         isOpen={isSuccessModalOpen}

--- a/src/features/participant-register-time-slot/ui/ParticipantEditTimeSlotPage.tsx
+++ b/src/features/participant-register-time-slot/ui/ParticipantEditTimeSlotPage.tsx
@@ -23,9 +23,7 @@ export default function ParticipantEditTimeSlotPage({
     isAllImpossible,
     isCtaActive,
     isSelected,
-    beginDrag,
-    updateDrag,
-    endDrag,
+    onCellTap,
     handleAllImpossibleChange,
     handleBack,
     handleSubmit,
@@ -66,9 +64,7 @@ export default function ParticipantEditTimeSlotPage({
             dates={dates}
             timeRange={timeRange}
             isSelected={isSelected}
-            beginDrag={beginDrag}
-            updateDrag={updateDrag}
-            endDrag={endDrag}
+            onCellTap={onCellTap}
           />
         </div>
 

--- a/src/features/participant-register-time-slot/ui/ParticipantRegisterTimeSlotPage.tsx
+++ b/src/features/participant-register-time-slot/ui/ParticipantRegisterTimeSlotPage.tsx
@@ -2,10 +2,9 @@
 
 import { useParticipantRegisterTimeSlot } from '@/features/participant-register-time-slot/model/useParticipantRegisterTimeSlot';
 import TimeSlotGrid from '@/features/participant-register-time-slot/ui/TimeSlotGrid';
+import TimeSlotPageFooter from '@/features/participant-register-time-slot/ui/TimeSlotPageFooter';
 import { trackEvent } from '@/shared/lib/amplitude';
 import SuccessBottomSheet from '@/shared/ui/bottom-sheet/SuccessBottomSheet';
-import Button from '@/shared/ui/button/Button';
-import Checkbox from '@/shared/ui/checkbox/Checkbox';
 import { Header } from '@/shared/ui/header/Header';
 import TopBar from '@/shared/ui/top-bar/TopBar';
 
@@ -58,7 +57,7 @@ export default function ParticipantRegisterTimeSlotPage({
       />
       <Header variant='subHeader' title={'가능한 시간을\n모두 선택해주세요'} />
 
-      <main className='flex flex-1 flex-col pt-1 pb-10'>
+      <main className='flex flex-1 flex-col pt-1 pb-36'>
         <div className='@container relative flex-1'>
           <TimeSlotGrid
             dates={dates}
@@ -67,29 +66,15 @@ export default function ParticipantRegisterTimeSlotPage({
             onCellTap={onCellTap}
           />
         </div>
-
-        <div className='mt-6 mb-6 px-5'>
-          <div
-            className='flex cursor-pointer items-center gap-2'
-            onClick={() => handleAllImpossibleChange(!isAllImpossible)}
-          >
-            <Checkbox checked={isAllImpossible} onChange={() => {}} />
-            <span className='text-body-4 text-text-secondary select-none'>
-              모든 날짜에 참여가 어려워요
-            </span>
-          </div>
-        </div>
-
-        <div className='px-5'>
-          <Button
-            onClick={handleSubmitWithTracking}
-            disabled={!isCtaActive}
-            fullWidth
-          >
-            투표하기
-          </Button>
-        </div>
       </main>
+
+      <TimeSlotPageFooter
+        isAllImpossible={isAllImpossible}
+        onAllImpossibleChange={handleAllImpossibleChange}
+        ctaLabel='투표하기'
+        isCtaActive={isCtaActive}
+        onCtaClick={handleSubmitWithTracking}
+      />
 
       <SuccessBottomSheet
         isOpen={isSuccessModalOpen}

--- a/src/features/participant-register-time-slot/ui/ParticipantRegisterTimeSlotPage.tsx
+++ b/src/features/participant-register-time-slot/ui/ParticipantRegisterTimeSlotPage.tsx
@@ -23,9 +23,7 @@ export default function ParticipantRegisterTimeSlotPage({
     isAllImpossible,
     isCtaActive,
     isSelected,
-    beginDrag,
-    updateDrag,
-    endDrag,
+    onCellTap,
     handleAllImpossibleChange,
     handleBack,
     handleSubmit,
@@ -66,9 +64,7 @@ export default function ParticipantRegisterTimeSlotPage({
             dates={dates}
             timeRange={timeRange}
             isSelected={isSelected}
-            beginDrag={beginDrag}
-            updateDrag={updateDrag}
-            endDrag={endDrag}
+            onCellTap={onCellTap}
           />
         </div>
 

--- a/src/features/participant-register-time-slot/ui/TimeSlotCell.tsx
+++ b/src/features/participant-register-time-slot/ui/TimeSlotCell.tsx
@@ -5,23 +5,24 @@ interface TimeSlotCellProps {
   slotIndex: number;
   isSelected: boolean;
   height: number;
+  onTap: (dateIndex: number, slotIndex: number) => void;
 }
 
-// 입력 화면 BASE 톤 (시안 기준): 결과 페이지의 4% opacity 보다 진하게.
-// 시안에서 1시간 박스 rounded-[10px] 윤곽이 명확히 보이는 정도.
-const INPUT_BASE_TONE = 'bg-[#F1F5FB]';
+// 시안 (Figma 3617:5634) 기준 BASE 톤 = #F9FAFB (Tailwind gray-50).
+// HeatmapCell 의 BASE_TONE_CLASS 와 동일 색 — 결과/입력/수정 일관.
+const INPUT_BASE_TONE = 'bg-gray-50';
 
 /**
- * 시간 슬롯 그리드 셀.
- * pointer 이벤트는 부모 `TimeSlotGrid` 가 elementFromPoint 로 처리한다
- * (셀 별로 setPointerCapture 를 사용하면 origin 셀이 후속 이벤트를 독점해서
- * 다른 셀에 진입해도 드래그가 퍼지지 않는 문제 회피).
+ * 시간 슬롯 그리드 셀. 탭(클릭) 으로만 선택 — 드래그 다중 선택은 의도적으로 막음.
+ * 같은 컬럼에서 두 번 탭하면 사이 구간이 채워지고, 다른 컬럼은 새 단일 선택으로
+ * 시작된다. 동작 규칙은 `useTimeSlotSelection` 참고.
  */
 export default function TimeSlotCell({
   dateIndex,
   slotIndex,
   isSelected,
   height,
+  onTap,
 }: TimeSlotCellProps) {
   const colorClass = isSelected ? 'bg-[#3C7EFA]' : INPUT_BASE_TONE;
 
@@ -30,10 +31,9 @@ export default function TimeSlotCell({
       type='button'
       role='gridcell'
       tabIndex={-1}
-      data-date-index={dateIndex}
-      data-slot-index={slotIndex}
       aria-selected={isSelected}
       style={{ height }}
+      onClick={() => onTap(dateIndex, slotIndex)}
       className={`box-border w-full cursor-pointer select-none ${colorClass}`}
     />
   );

--- a/src/features/participant-register-time-slot/ui/TimeSlotGrid.tsx
+++ b/src/features/participant-register-time-slot/ui/TimeSlotGrid.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { isSameWeek } from 'date-fns';
-import { type PointerEvent as ReactPointerEvent, useRef } from 'react';
 
 import { type TimeRangeWithSlotCount } from '@/entities/meet/dto/meet.dto';
 import TimeSlotCell from '@/features/participant-register-time-slot/ui/TimeSlotCell';
 import { parseDate } from '@/shared/lib/date';
 
-const SLOT_H = 40;
+// 시안 (Figma 3627:6217) 기준: 셀 32px, 1시간 그룹 64px, corner radius 8px.
+const SLOT_H = 32;
 const HOUR_H = SLOT_H * 2;
 const TIME_COL_W = 40;
 const DAY_HEADER_H = 56;
@@ -43,9 +43,7 @@ interface TimeSlotGridProps {
   dates: string[];
   timeRange: TimeRangeWithSlotCount;
   isSelected: (dateIndex: number, slotIndex: number) => boolean;
-  beginDrag: (dateIndex: number, slotIndex: number) => void;
-  updateDrag: (dateIndex: number, slotIndex: number) => void;
-  endDrag: () => void;
+  onCellTap: (dateIndex: number, slotIndex: number) => void;
 }
 
 function timeToMinutes(t: string): number {
@@ -53,34 +51,11 @@ function timeToMinutes(t: string): number {
   return hh * 60 + mm;
 }
 
-/**
- * `clientX/clientY` 위치의 셀 좌표(`dateIndex`, `slotIndex`) 를 추출.
- * data attribute 로 셀을 식별. 셀 외 영역(헤더/시간 컬럼/패딩) 이면 null.
- */
-function getCellAtPoint(
-  x: number,
-  y: number,
-): {
-  dateIndex: number;
-  slotIndex: number;
-} | null {
-  const el = document.elementFromPoint(x, y);
-  if (!el) return null;
-  const cellEl = el.closest('[data-date-index]') as HTMLElement | null;
-  if (!cellEl) return null;
-  const dateIndex = Number(cellEl.dataset.dateIndex);
-  const slotIndex = Number(cellEl.dataset.slotIndex);
-  if (Number.isNaN(dateIndex) || Number.isNaN(slotIndex)) return null;
-  return { dateIndex, slotIndex };
-}
-
 export default function TimeSlotGrid({
   dates,
   timeRange,
   isSelected,
-  beginDrag,
-  updateDrag,
-  endDrag,
+  onCellTap,
 }: TimeSlotGridProps) {
   // timeRange 의 startTime ~ endTime 만 표시.
   // 1시간 = 2 슬롯 그룹으로 묶음.
@@ -123,49 +98,12 @@ export default function TimeSlotGrid({
 
   const colWidth = buildColWidth(dates.length);
 
-  // 마지막 드래그 셀 좌표 — 같은 셀에서 pointermove 가 반복되어도 updateDrag 재호출 방지.
-  const lastCellRef = useRef<{ dateIndex: number; slotIndex: number } | null>(
-    null,
-  );
-
-  const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
-    const cell = getCellAtPoint(e.clientX, e.clientY);
-    if (!cell) return;
-    e.preventDefault();
-    e.currentTarget.setPointerCapture?.(e.pointerId);
-    lastCellRef.current = cell;
-    beginDrag(cell.dateIndex, cell.slotIndex);
-  };
-
-  const handlePointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
-    if (lastCellRef.current === null) return;
-    const cell = getCellAtPoint(e.clientX, e.clientY);
-    if (!cell) return;
-    const last = lastCellRef.current;
-    if (last.dateIndex === cell.dateIndex && last.slotIndex === cell.slotIndex)
-      return;
-    lastCellRef.current = cell;
-    updateDrag(cell.dateIndex, cell.slotIndex);
-  };
-
-  const handlePointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
-    lastCellRef.current = null;
-    endDrag();
-    if (e.currentTarget.hasPointerCapture?.(e.pointerId)) {
-      e.currentTarget.releasePointerCapture?.(e.pointerId);
-    }
-  };
-
   return (
     <div
       role='grid'
       aria-rowcount={timeRange.slotCount + 1}
       aria-colcount={dates.length + 1}
-      className='flex w-full touch-none overflow-auto pb-5'
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
-      onPointerCancel={handlePointerUp}
+      className='flex w-full overflow-auto pb-5'
     >
       <div
         className='sticky left-0 z-20 shrink-0 bg-white'
@@ -173,16 +111,22 @@ export default function TimeSlotGrid({
       >
         <div style={{ height: DAY_HEADER_H }} />
         <div className='flex flex-col' style={{ gap: ROW_GAP }}>
-          {groups.map((group) => (
-            <div
-              key={group.hour}
-              role='rowheader'
-              style={{ height: HOUR_H }}
-              className='text-text-tertiary flex items-start justify-end pr-2 text-[14px] leading-5 font-medium'
-            >
-              {group.hour}
-            </div>
-          ))}
+          {groups.map((group) => {
+            const visibleSlots =
+              (group.topSlotIdx !== null ? 1 : 0) +
+              (group.botSlotIdx !== null ? 1 : 0);
+            const rowHeight = visibleSlots === 1 ? SLOT_H : HOUR_H;
+            return (
+              <div
+                key={group.hour}
+                role='rowheader'
+                style={{ height: rowHeight }}
+                className='text-text-tertiary flex items-start justify-end pr-2 text-[14px] leading-5 font-medium'
+              >
+                {group.hour}
+              </div>
+            );
+          })}
         </div>
       </div>
 
@@ -230,39 +174,55 @@ export default function TimeSlotGrid({
               </div>
 
               <div className='flex flex-col' style={{ gap: ROW_GAP }}>
-                {groups.map((group) => (
-                  <div
-                    key={`${date}-${group.hour}`}
-                    role='row'
-                    className='overflow-hidden rounded-[10px]'
-                    style={{ height: HOUR_H }}
-                  >
-                    {group.topSlotIdx !== null ? (
-                      <TimeSlotCell
-                        dateIndex={dateIndex}
-                        slotIndex={group.topSlotIdx}
-                        isSelected={isSelected(dateIndex, group.topSlotIdx)}
-                        height={SLOT_H}
-                      />
-                    ) : (
-                      <div style={{ height: SLOT_H }} />
-                    )}
+                {groups.map((group) => {
+                  const hasTop = group.topSlotIdx !== null;
+                  const hasBot = group.botSlotIdx !== null;
+                  const visibleSlots = (hasTop ? 1 : 0) + (hasBot ? 1 : 0);
+                  const rowHeight = visibleSlots === 1 ? SLOT_H : HOUR_H;
+
+                  return (
                     <div
-                      className='border-t border-dashed border-white/40'
-                      style={{ marginTop: -1 }}
-                    />
-                    {group.botSlotIdx !== null ? (
-                      <TimeSlotCell
-                        dateIndex={dateIndex}
-                        slotIndex={group.botSlotIdx}
-                        isSelected={isSelected(dateIndex, group.botSlotIdx)}
-                        height={SLOT_H}
-                      />
-                    ) : (
-                      <div style={{ height: SLOT_H }} />
-                    )}
-                  </div>
-                ))}
+                      key={`${date}-${group.hour}`}
+                      role='row'
+                      className='rounded-dropdown relative flex flex-col overflow-hidden'
+                      style={{ height: rowHeight }}
+                    >
+                      {hasTop && (
+                        <TimeSlotCell
+                          dateIndex={dateIndex}
+                          slotIndex={group.topSlotIdx as number}
+                          isSelected={isSelected(
+                            dateIndex,
+                            group.topSlotIdx as number,
+                          )}
+                          height={SLOT_H}
+                          onTap={onCellTap}
+                        />
+                      )}
+                      {hasBot && (
+                        <TimeSlotCell
+                          dateIndex={dateIndex}
+                          slotIndex={group.botSlotIdx as number}
+                          isSelected={isSelected(
+                            dateIndex,
+                            group.botSlotIdx as number,
+                          )}
+                          height={SLOT_H}
+                          onTap={onCellTap}
+                        />
+                      )}
+                      {hasTop && hasBot && (
+                        // absolute 로 띄워 flow 영향 0. 두 셀 사이 정확히 가운데에 점선.
+                        // 점선 색은 시안 #E6E8EB (≈ border-gray-200) — 셀 색 무관 항상 회색.
+                        <div
+                          aria-hidden
+                          className='pointer-events-none absolute right-0 left-0 border-t border-dashed border-gray-200'
+                          style={{ top: SLOT_H }}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </div>
           );

--- a/src/features/participant-register-time-slot/ui/TimeSlotPageFooter.tsx
+++ b/src/features/participant-register-time-slot/ui/TimeSlotPageFooter.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Button from '@/shared/ui/button/Button';
+import Checkbox from '@/shared/ui/checkbox/Checkbox';
+
+interface TimeSlotPageFooterProps {
+  isAllImpossible: boolean;
+  onAllImpossibleChange: (checked: boolean) => void;
+  ctaLabel: string;
+  isCtaActive: boolean;
+  onCtaClick: () => void;
+}
+
+/**
+ * 참여자 시간 슬롯 등록/수정 페이지 하단 고정 푸터.
+ * `VoteActionButtons` 와 동일한 fixed-bottom 패턴 (sm 폭 컨테이너 중앙 정렬 + 위쪽 흰색 그림자).
+ */
+export default function TimeSlotPageFooter({
+  isAllImpossible,
+  onAllImpossibleChange,
+  ctaLabel,
+  isCtaActive,
+  onCtaClick,
+}: TimeSlotPageFooterProps) {
+  return (
+    <div className='fixed right-0 bottom-0 left-0 z-50 mx-auto w-full max-w-screen-sm bg-white px-5 pt-3 pb-4 shadow-[0px_-7px_20px_10px_#ffffff]'>
+      <div
+        className='mb-3 flex cursor-pointer items-center gap-2'
+        onClick={() => onAllImpossibleChange(!isAllImpossible)}
+      >
+        <Checkbox checked={isAllImpossible} onChange={() => {}} />
+        <span className='text-body-4 text-text-secondary select-none'>
+          모든 날짜에 참여가 어려워요
+        </span>
+      </div>
+      <Button onClick={onCtaClick} disabled={!isCtaActive} fullWidth>
+        {ctaLabel}
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #84

# 📝 작업 내용

## 인터랙션: 드래그 다중 선택 → 탭-탭 구간 선택
모바일에서 셀 드래그가 페이지 스크롤과 충돌하던 문제를 해결.

`useTimeSlotSelection` 의 동작 규칙:

| 첫 탭 | 두 번째 탭 (같은 컬럼) | 결과 |
|---|---|---|
| 빈 셀 A | 빈 셀 B | A~B 구간 **선택** |
| 선택된 셀 A | 선택된 셀 B | A~B 구간 **해제** |
| 다른 컬럼 / mode 불일치 | — | 단일 탭으로 재시작, 앵커 갱신 |

- 앵커는 `{ dateIndex, slotIndex, mode: 'add' | 'remove' }`.
- StrictMode 안전성: `anchorRef.current` 변이를 `setSelected` 업데이터 밖으로 이동.
- `getCellAtPoint` / `setPointerCapture` / 포인터 핸들러 전부 제거.
- `TimeSlotCell` 의 `touch-none` 제거 → 페이지 스크롤 정상화.

## 셀 디자인 시안 매칭 (입력/결과 일관성)
- `BASE_TONE_CLASS` → `bg-gray-50` (#F9FAFB).
- `SLOT_H=32`, `HOUR_H=64`, `rounded-dropdown` 으로 두 그리드 통일.
- 30분 오프셋 시작 시 row height 동적 계산 (부분 그룹은 SLOT_H).
- 두 셀 사이 점선을 absolute 배치 + `border-gray-200` 으로 색 통일.

## 정리
- 미사용 함수 `rectKeys` 와 그 테스트 4건 제거.

## 시안
- Figma 3617:5634 (입력 셀)
- Figma 3770:6061 (결과 셀)
- Figma 3627:6217 (셀 디테일)

# 🗣️ 리뷰 요구사항 (선택)

- 모바일 기기에서 같은 컬럼 두 번 탭 → 구간 선택 / 두 번 탭 → 구간 해제 동작 확인.
- 다른 컬럼 / mode 불일치 시 단일 탭으로 재시작되는지 확인.
- 결과 화면(`/meet/{id}`) 과 입력 화면(`/meet/{id}/register/date`) BASE 셀 색 일치 확인.